### PR TITLE
feat(M9): Template System Extensions v1.1.0

### DIFF
--- a/platform/engine/template-loader.ts
+++ b/platform/engine/template-loader.ts
@@ -167,6 +167,105 @@ function validateManifest(manifest: Record<string, unknown>) {
     }
   }
 
+  // Validate governance structure (optional, v1.1.0+)
+  if (manifest.governance !== undefined) {
+    const gov = manifest.governance as Record<string, unknown>;
+    if (typeof gov !== 'object' || gov === null) {
+      errors.push('governance must be an object');
+    } else {
+      const validModes = ['off', 'advisory', 'enforcing'];
+      if (!gov.default_mode || !validModes.includes(gov.default_mode as string)) {
+        errors.push(`governance.default_mode must be one of: ${validModes.join(', ')}`);
+      }
+      if (!gov.policies_file || typeof gov.policies_file !== 'string') {
+        errors.push('governance.policies_file must be a non-empty string');
+      }
+      if (gov.gates !== undefined) {
+        if (typeof gov.gates !== 'object' || gov.gates === null) {
+          errors.push('governance.gates must be an object');
+        } else {
+          for (const [gateId, gateCfg] of Object.entries(
+            gov.gates as Record<string, Record<string, unknown>>
+          )) {
+            if (!gateCfg.policy || typeof gateCfg.policy !== 'string') {
+              errors.push(`governance.gates['${gateId}'].policy must be a non-empty string`);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Validate phaseTools structure (optional, v1.1.0+)
+  if (manifest.phaseTools !== undefined) {
+    if (typeof manifest.phaseTools !== 'object' || manifest.phaseTools === null) {
+      errors.push('phaseTools must be an object');
+    } else {
+      for (const [phase, toolCfg] of Object.entries(
+        manifest.phaseTools as Record<string, Record<string, unknown>>
+      )) {
+        if (toolCfg.required !== undefined && !Array.isArray(toolCfg.required)) {
+          errors.push(`phaseTools['${phase}'].required must be an array`);
+        }
+        if (toolCfg.optional !== undefined && !Array.isArray(toolCfg.optional)) {
+          errors.push(`phaseTools['${phase}'].optional must be an array`);
+        }
+        const allTools = [
+          ...((toolCfg.required || []) as Array<Record<string, unknown>>),
+          ...((toolCfg.optional || []) as Array<Record<string, unknown>>),
+        ];
+        for (let i = 0; i < allTools.length; i++) {
+          if (!allTools[i].adapter || typeof allTools[i].adapter !== 'string') {
+            errors.push(`phaseTools['${phase}'] tool[${i}] must have an 'adapter' string`);
+          }
+        }
+      }
+    }
+  }
+
+  // Validate lifecycle structure (optional, v1.1.0+)
+  if (manifest.lifecycle !== undefined) {
+    const lc = manifest.lifecycle as Record<string, unknown>;
+    if (typeof lc !== 'object' || lc === null) {
+      errors.push('lifecycle must be an object');
+    } else {
+      if (!Array.isArray(lc.stages) || lc.stages.length === 0) {
+        errors.push('lifecycle.stages must be a non-empty array');
+      }
+      if (lc.transitions !== undefined) {
+        if (!Array.isArray(lc.transitions)) {
+          errors.push('lifecycle.transitions must be an array');
+        } else {
+          const validGateTypes = [
+            'artifact_approved',
+            'governance_approved',
+            'tool_healthy',
+            'metric_threshold',
+            'manual_confirmation',
+          ];
+          for (let i = 0; i < lc.transitions.length; i++) {
+            const t = lc.transitions[i] as Record<string, unknown>;
+            if (!t.from || !t.to) {
+              errors.push(`lifecycle.transitions[${i}] must have 'from' and 'to'`);
+            }
+            if (t.gates && Array.isArray(t.gates)) {
+              for (let g = 0; g < (t.gates as Array<Record<string, unknown>>).length; g++) {
+                const gate = (t.gates as Array<Record<string, unknown>>)[g];
+                if (!gate.id || !gate.type) {
+                  errors.push(`lifecycle.transitions[${i}].gates[${g}] must have 'id' and 'type'`);
+                } else if (!validGateTypes.includes(gate.type as string)) {
+                  errors.push(
+                    `lifecycle.transitions[${i}].gates[${g}].type '${gate.type}' is invalid (${validGateTypes.join(', ')})`
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 
@@ -203,6 +302,20 @@ function resolveTemplatePaths(manifest: Record<string, unknown>, templateRoot: s
     criticToPhase: manifest.criticToPhase,
     modes: manifest.modes,
     decisionCategories: manifest.decisionCategories || [],
+    phaseArtifacts: manifest.phaseArtifacts || {},
+    phaseLineage: manifest.phaseLineage || {},
+    outputTemplates: manifest.outputTemplates || [],
+    governance: manifest.governance
+      ? {
+          ...(manifest.governance as Record<string, unknown>),
+          policies_file: path.join(
+            templateRoot,
+            (manifest.governance as Record<string, string>).policies_file
+          ),
+        }
+      : null,
+    phaseTools: manifest.phaseTools || {},
+    lifecycle: manifest.lifecycle || null,
   };
 }
 

--- a/platform/schema/template-manifest.schema.json
+++ b/platform/schema/template-manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://myagentic-it.local/schema/template-manifest.schema.json",
   "title": "Template Manifest Schema",
-  "description": "Defines the structure of a template pack manifest. Each template provides agents, contracts, guardrails, playbooks, and flow definitions for a specific domain.",
+  "description": "Defines the structure of a template pack manifest. Each template provides agents, contracts, guardrails, playbooks, flow definitions, governance policies, tool requirements, and lifecycle rules for a specific domain.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -24,7 +24,7 @@
     "schemaVersion": {
       "type": "string",
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
-      "description": "Schema version for this manifest format."
+      "description": "Schema version for this manifest format (1.0.0 or 1.1.0)."
     },
     "name": {
       "type": "string",
@@ -71,6 +71,16 @@
       "type": "string",
       "minLength": 1,
       "description": "Path to playbooks directory relative to the template root."
+    },
+    "decisionsDir": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to decisions directory relative to the template root."
+    },
+    "decisionIndexSeed": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the decision index seed file relative to the template root."
     },
     "decisionCategories": {
       "type": "array",
@@ -166,6 +176,273 @@
         }
       },
       "description": "Command mode definitions (CREATE, AUDIT, etc.)."
+    },
+    "phaseArtifacts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "type", "stage", "path"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Unique artifact identifier (e.g. 'P1-BA-analysis')."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "DOCUMENT",
+                "DESIGN_ASSET",
+                "CONFIGURATION",
+                "CODE",
+                "TEST_RESULT",
+                "DEPLOYMENT"
+              ],
+              "description": "Artifact type classification."
+            },
+            "stage": {
+              "type": "string",
+              "enum": [
+                "IDEA",
+                "REQUIREMENTS",
+                "ARCHITECTURE",
+                "PLANNING",
+                "DEVELOPMENT",
+                "TESTING",
+                "STAGING",
+                "RELEASE",
+                "PRODUCTION",
+                "MONITORING",
+                "IMPROVEMENT"
+              ],
+              "description": "Lifecycle stage this artifact belongs to."
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Output path relative to the project root."
+            },
+            "agent": {
+              "type": "string",
+              "description": "Agent ID that produces this artifact."
+            },
+            "required": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether this artifact is required for phase completion."
+            },
+            "pattern": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether the path is a glob pattern (e.g. 'decisions/*.md')."
+            }
+          }
+        }
+      },
+      "description": "Maps phase names to artifact declarations (produces list)."
+    },
+    "phaseLineage": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "consumes": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "description": "Phase IDs whose artifacts this phase consumes."
+          }
+        }
+      },
+      "description": "Dependency graph between phases (which phases consume outputs from other phases)."
+    },
+    "outputTemplates": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Paths to output template files relative to the template root."
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default_mode", "policies_file"],
+      "properties": {
+        "default_mode": {
+          "type": "string",
+          "enum": ["off", "advisory", "enforcing"],
+          "description": "Default governance mode for this template."
+        },
+        "policies_file": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to governance policies JSON file relative to the template root."
+        },
+        "gates": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["policy"],
+            "properties": {
+              "policy": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Policy ID from the policies file to apply at this gate."
+              },
+              "override_allowed": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this gate's policy can be overridden with --force."
+              }
+            }
+          },
+          "description": "Maps gate IDs to governance policy assignments."
+        }
+      },
+      "description": "Governance configuration — policy references and gate assignments."
+    },
+    "phaseTools": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "required": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["adapter"],
+              "properties": {
+                "adapter": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Adapter identifier (e.g. 'git', 'testing', 'ci')."
+                },
+                "operations": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Specific operations needed from this adapter."
+                }
+              }
+            },
+            "description": "Adapters that must be healthy before the phase can start."
+          },
+          "optional": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["adapter"],
+              "properties": {
+                "adapter": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Adapter identifier."
+                },
+                "operations": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "description": "Specific operations needed from this adapter."
+                }
+              }
+            },
+            "description": "Adapters that enhance the phase but are not required."
+          }
+        }
+      },
+      "description": "Maps phase names to tool/adapter requirements."
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stages"],
+      "properties": {
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Ordered list of lifecycle stages."
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "to"],
+            "properties": {
+              "from": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Source lifecycle stage."
+              },
+              "to": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Target lifecycle stage."
+              },
+              "gates": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["id", "type"],
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Unique gate identifier."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Human-readable description of this gate condition."
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "artifact_approved",
+                        "governance_approved",
+                        "tool_healthy",
+                        "metric_threshold",
+                        "manual_confirmation"
+                      ],
+                      "description": "Gate evaluation type."
+                    },
+                    "artifact": {
+                      "type": "string",
+                      "description": "Artifact ID reference (for artifact_approved type)."
+                    },
+                    "policy": {
+                      "type": "string",
+                      "description": "Policy ID reference (for governance_approved type)."
+                    },
+                    "adapter": {
+                      "type": "string",
+                      "description": "Adapter ID reference (for tool_healthy type)."
+                    },
+                    "metric": {
+                      "type": "string",
+                      "description": "Metric name (for metric_threshold type)."
+                    },
+                    "threshold": {
+                      "type": "number",
+                      "description": "Threshold value (for metric_threshold type)."
+                    }
+                  }
+                },
+                "description": "Gate conditions that must be satisfied for this transition."
+              }
+            }
+          },
+          "description": "Lifecycle stage transition rules with gate conditions."
+        }
+      },
+      "description": "Lifecycle configuration — stages and transition rules with gates."
     }
   }
 }

--- a/scripts/generate-platform.js
+++ b/scripts/generate-platform.js
@@ -22,8 +22,14 @@ const path = require('node:path');
 const ROOT = path.resolve(__dirname, '..');
 const SCHEMA_DIR = path.join(ROOT, 'platform', 'schema');
 const OUTPUT_DIR = path.join(ROOT, 'platform', 'generated');
+const MANIFEST_PATH = path.join(ROOT, 'templates', 'sdlc', 'manifest.json');
 
 function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readJsonOptional(filePath) {
+  if (!fs.existsSync(filePath)) return null;
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
@@ -41,6 +47,7 @@ function loadCanonical() {
     agents: readJson(path.join(SCHEMA_DIR, 'agents.json')),
     flows: readJson(path.join(SCHEMA_DIR, 'flows.json')),
     tools: readJson(path.join(SCHEMA_DIR, 'tools.json')),
+    manifest: readJsonOptional(MANIFEST_PATH),
   };
 }
 
@@ -50,7 +57,7 @@ function generateCopilot(canonical) {
   const outDir = path.join(OUTPUT_DIR, 'copilot');
   ensureDir(outDir);
 
-  const { agents, flows, tools } = canonical;
+  const { agents, flows, tools, manifest } = canonical;
   const lines = [];
 
   lines.push('# GitHub Copilot Agent Instructions (Auto-Generated)');
@@ -107,6 +114,65 @@ function generateCopilot(canonical) {
   }
   lines.push('');
 
+  // Extended manifest context (v1.1.0+)
+  if (manifest) {
+    if (manifest.phaseArtifacts) {
+      lines.push('## Phase Artifacts');
+      lines.push('');
+      for (const [phase, artifacts] of Object.entries(manifest.phaseArtifacts)) {
+        lines.push(`### ${phase}`);
+        lines.push('');
+        lines.push('| ID | Type | Stage | Path |');
+        lines.push('| --- | --- | --- | --- |');
+        for (const a of artifacts) {
+          lines.push(`| ${a.id} | ${a.type} | ${a.stage} | ${a.path} |`);
+        }
+        lines.push('');
+      }
+    }
+
+    if (manifest.phaseTools && Object.keys(manifest.phaseTools).length > 0) {
+      lines.push('## Phase Tool Requirements');
+      lines.push('');
+      for (const [phase, toolCfg] of Object.entries(manifest.phaseTools)) {
+        const req = (toolCfg.required || []).map((t) => t.adapter);
+        const opt = (toolCfg.optional || []).map((t) => t.adapter);
+        if (req.length > 0 || opt.length > 0) {
+          lines.push(`- **${phase}**: required=[${req.join(', ')}] optional=[${opt.join(', ')}]`);
+        }
+      }
+      lines.push('');
+    }
+
+    if (manifest.governance) {
+      lines.push('## Governance');
+      lines.push('');
+      lines.push(`- Default mode: ${manifest.governance.default_mode}`);
+      if (manifest.governance.gates) {
+        for (const [gate, cfg] of Object.entries(manifest.governance.gates)) {
+          lines.push(`- ${gate}: policy=${cfg.policy}, override=${cfg.override_allowed}`);
+        }
+      }
+      lines.push('');
+    }
+
+    if (manifest.lifecycle) {
+      lines.push('## Lifecycle Stages');
+      lines.push('');
+      lines.push(`Stages: ${manifest.lifecycle.stages.join(' → ')}`);
+      lines.push('');
+      if (manifest.lifecycle.transitions) {
+        lines.push('### Transitions');
+        lines.push('');
+        for (const t of manifest.lifecycle.transitions) {
+          const gateCount = t.gates ? t.gates.length : 0;
+          lines.push(`- ${t.from} → ${t.to} (${gateCount} gate${gateCount !== 1 ? 's' : ''})`);
+        }
+        lines.push('');
+      }
+    }
+  }
+
   const content = lines.join('\n');
   const outPath = path.join(outDir, 'copilot-instructions.md');
   fs.writeFileSync(outPath, content, 'utf8');
@@ -155,6 +221,34 @@ function generateCopilot(canonical) {
         agentLines.push(`- Agent ${dep}: ${depAgent ? depAgent.name : 'unknown'}`);
       }
       agentLines.push('');
+    }
+
+    // Extended context from manifest (v1.1.0+)
+    if (manifest && manifest.phaseArtifacts) {
+      const phaseArtifacts = manifest.phaseArtifacts[agent.phase];
+      if (phaseArtifacts && phaseArtifacts.length > 0) {
+        agentLines.push('## Artifacts');
+        agentLines.push('');
+        for (const a of phaseArtifacts) {
+          agentLines.push(`- \`${a.id}\` (${a.type}) → ${a.path}`);
+        }
+        agentLines.push('');
+      }
+    }
+
+    if (manifest && manifest.phaseTools) {
+      const toolCfg = manifest.phaseTools[agent.phase];
+      if (toolCfg) {
+        const req = (toolCfg.required || []).map((t) => t.adapter);
+        const opt = (toolCfg.optional || []).map((t) => t.adapter);
+        if (req.length > 0 || opt.length > 0) {
+          agentLines.push('## Tool Requirements');
+          agentLines.push('');
+          if (req.length > 0) agentLines.push(`- Required: ${req.join(', ')}`);
+          if (opt.length > 0) agentLines.push(`- Optional: ${opt.join(', ')}`);
+          agentLines.push('');
+        }
+      }
     }
 
     const safeName = agent.name

--- a/templates/sdlc/manifest.json
+++ b/templates/sdlc/manifest.json
@@ -1,7 +1,7 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "name": "sdlc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "Software Development Lifecycle",
   "description": "End-to-end new software solution creation through a structured multi-agent process across four phases: Requirements & Strategy, Architecture & Design, Experience Design, and Brand & Growth.",
   "flowsFile": "flows.yaml",
@@ -394,5 +394,164 @@
     "output-templates/guardrail-template.md",
     "output-templates/sprint-completion-report-template.md",
     "output-templates/sprint-retrospective-template.md"
-  ]
+  ],
+  "governance": {
+    "default_mode": "advisory",
+    "policies_file": "governance-policies.json",
+    "gates": {
+      "CRITIC_1": {
+        "policy": "REQUIREMENT_TO_DESIGN",
+        "override_allowed": true
+      },
+      "CRITIC_2": {
+        "policy": "DESIGN_TO_DEVELOPMENT",
+        "override_allowed": false
+      },
+      "CRITIC_3": {
+        "policy": "UX_TO_BRAND",
+        "override_allowed": true
+      },
+      "CRITIC_4": {
+        "policy": "BRAND_TO_SYNTHESIS",
+        "override_allowed": true
+      },
+      "SPRINT_GATE": {
+        "policy": "DEVELOPMENT_TO_TESTING",
+        "override_allowed": true
+      }
+    }
+  },
+  "phaseTools": {
+    "PHASE_1": {
+      "required": [],
+      "optional": [{ "adapter": "git", "operations": ["list_commits"] }]
+    },
+    "PHASE_2": {
+      "required": [],
+      "optional": [
+        { "adapter": "git", "operations": ["list_branches", "list_commits"] },
+        { "adapter": "security", "operations": ["audit_dependencies"] }
+      ]
+    },
+    "PHASE_3": {
+      "required": [],
+      "optional": []
+    },
+    "PHASE_4": {
+      "required": [],
+      "optional": []
+    },
+    "PHASE_5_EXECUTING": {
+      "required": [
+        { "adapter": "git", "operations": ["create_branch", "list_commits", "commit"] },
+        { "adapter": "testing", "operations": ["run_unit_tests"] }
+      ],
+      "optional": [
+        { "adapter": "ci", "operations": ["trigger_workflow"] },
+        { "adapter": "security", "operations": ["run_sast", "scan_secrets"] },
+        { "adapter": "container", "operations": ["build"] }
+      ]
+    }
+  },
+  "lifecycle": {
+    "stages": [
+      "IDEA",
+      "REQUIREMENTS",
+      "ARCHITECTURE",
+      "PLANNING",
+      "DEVELOPMENT",
+      "TESTING",
+      "STAGING",
+      "RELEASE",
+      "PRODUCTION",
+      "MONITORING",
+      "IMPROVEMENT"
+    ],
+    "transitions": [
+      {
+        "from": "REQUIREMENTS",
+        "to": "ARCHITECTURE",
+        "gates": [
+          {
+            "id": "G-ARCH-01",
+            "description": "Business requirements analysis completed",
+            "type": "artifact_approved",
+            "artifact": "P1-BA-analysis"
+          }
+        ]
+      },
+      {
+        "from": "ARCHITECTURE",
+        "to": "PLANNING",
+        "gates": [
+          {
+            "id": "G-PLAN-01",
+            "description": "Architecture review completed",
+            "type": "artifact_approved",
+            "artifact": "P2-SA-analysis"
+          },
+          {
+            "id": "G-PLAN-02",
+            "description": "Security review completed",
+            "type": "artifact_approved",
+            "artifact": "P2-SEC-guardrails"
+          }
+        ]
+      },
+      {
+        "from": "PLANNING",
+        "to": "DEVELOPMENT",
+        "gates": [
+          {
+            "id": "G-DEV-01",
+            "description": "Sprint plan approved",
+            "type": "governance_approved",
+            "policy": "DESIGN_TO_DEVELOPMENT"
+          },
+          {
+            "id": "G-DEV-02",
+            "description": "Git adapter healthy",
+            "type": "tool_healthy",
+            "adapter": "git"
+          }
+        ]
+      },
+      {
+        "from": "DEVELOPMENT",
+        "to": "TESTING",
+        "gates": [
+          {
+            "id": "G-TEST-01",
+            "description": "Unit tests passing",
+            "type": "tool_healthy",
+            "adapter": "testing"
+          }
+        ]
+      },
+      {
+        "from": "TESTING",
+        "to": "STAGING",
+        "gates": [
+          {
+            "id": "G-STAGE-01",
+            "description": "All tests pass",
+            "type": "metric_threshold",
+            "metric": "test_pass_rate",
+            "threshold": 95
+          }
+        ]
+      },
+      {
+        "from": "STAGING",
+        "to": "RELEASE",
+        "gates": [
+          {
+            "id": "G-REL-01",
+            "description": "Release approval",
+            "type": "manual_confirmation"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/tests/unit/template-loader.test.js
+++ b/tests/unit/template-loader.test.js
@@ -90,8 +90,8 @@ describe('loadManifest', () => {
   test('loads the real SDLC manifest', () => {
     const manifest = loadManifest('sdlc', TEMPLATES_DIR);
     expect(manifest.name).toBe('sdlc');
-    expect(manifest.schemaVersion).toBe('1.0.0');
-    expect(manifest.version).toBe('1.0.0');
+    expect(manifest.schemaVersion).toBe('1.1.0');
+    expect(manifest.version).toBe('1.1.0');
   });
 
   test('throws for non-existent template', () => {
@@ -365,7 +365,7 @@ describe('listTemplates', () => {
     const sdlc = templates.find((t) => t.name === 'sdlc');
     expect(sdlc).toBeDefined();
     expect(sdlc.valid).toBe(true);
-    expect(sdlc.version).toBe('1.0.0');
+    expect(sdlc.version).toBe('1.1.0');
     expect(sdlc.displayName).toBe('Software Development Lifecycle');
   });
 
@@ -547,6 +547,363 @@ describe('seedDecisions', () => {
       const content = fs.readFileSync(path.join(targetDecDir, file), 'utf8');
       // Every seed file should start with a markdown heading
       expect(content.startsWith('#')).toBe(true);
+    }
+  });
+});
+
+// ─── Template System Extensions (M9 / v1.1.0) ───────────────
+
+describe('validateManifest — governance (v1.1.0)', () => {
+  test('accepts manifest with valid governance section', () => {
+    const manifest = createMinimalManifest({
+      governance: {
+        default_mode: 'advisory',
+        policies_file: 'governance-policies.json',
+        gates: {
+          CRITIC_1: { policy: 'REQUIREMENT_TO_DESIGN', override_allowed: true },
+        },
+      },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('accepts manifest without governance (backward compat)', () => {
+    const manifest = createMinimalManifest();
+    delete manifest.governance;
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects governance with invalid default_mode', () => {
+    const manifest = createMinimalManifest({
+      governance: { default_mode: 'invalid', policies_file: 'x.json' },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('default_mode'))).toBe(true);
+  });
+
+  test('rejects governance without policies_file', () => {
+    const manifest = createMinimalManifest({
+      governance: { default_mode: 'advisory' },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('policies_file'))).toBe(true);
+  });
+
+  test('rejects governance gate without policy', () => {
+    const manifest = createMinimalManifest({
+      governance: {
+        default_mode: 'advisory',
+        policies_file: 'x.json',
+        gates: { CRITIC_1: { override_allowed: true } },
+      },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('policy'))).toBe(true);
+  });
+
+  test('accepts all three governance modes', () => {
+    for (const mode of ['off', 'advisory', 'enforcing']) {
+      const manifest = createMinimalManifest({
+        governance: { default_mode: mode, policies_file: 'x.json' },
+      });
+      const result = validateManifest(manifest);
+      expect(result.valid).toBe(true);
+    }
+  });
+});
+
+describe('validateManifest — phaseTools (v1.1.0)', () => {
+  test('accepts manifest with valid phaseTools', () => {
+    const manifest = createMinimalManifest({
+      phaseTools: {
+        PHASE_5_EXECUTING: {
+          required: [{ adapter: 'git', operations: ['create_branch'] }],
+          optional: [{ adapter: 'ci', operations: ['trigger_workflow'] }],
+        },
+      },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  test('accepts manifest without phaseTools (backward compat)', () => {
+    const manifest = createMinimalManifest();
+    delete manifest.phaseTools;
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects phaseTools with non-array required', () => {
+    const manifest = createMinimalManifest({
+      phaseTools: { PHASE_1: { required: 'not-array' } },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('required must be an array'))).toBe(true);
+  });
+
+  test('rejects tool entry without adapter', () => {
+    const manifest = createMinimalManifest({
+      phaseTools: {
+        PHASE_1: { required: [{ operations: ['test'] }] },
+      },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('adapter'))).toBe(true);
+  });
+});
+
+describe('validateManifest — lifecycle (v1.1.0)', () => {
+  test('accepts manifest with valid lifecycle', () => {
+    const manifest = createMinimalManifest({
+      lifecycle: {
+        stages: ['IDEA', 'REQUIREMENTS', 'DESIGN'],
+        transitions: [
+          {
+            from: 'REQUIREMENTS',
+            to: 'DESIGN',
+            gates: [{ id: 'G-01', type: 'artifact_approved', artifact: 'P1-BA-analysis' }],
+          },
+        ],
+      },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  test('accepts manifest without lifecycle (backward compat)', () => {
+    const manifest = createMinimalManifest();
+    delete manifest.lifecycle;
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects lifecycle with empty stages', () => {
+    const manifest = createMinimalManifest({
+      lifecycle: { stages: [] },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('stages must be a non-empty array'))).toBe(true);
+  });
+
+  test('rejects lifecycle transition without from/to', () => {
+    const manifest = createMinimalManifest({
+      lifecycle: { stages: ['A', 'B'], transitions: [{ to: 'B' }] },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("'from' and 'to'"))).toBe(true);
+  });
+
+  test('rejects lifecycle gate with invalid type', () => {
+    const manifest = createMinimalManifest({
+      lifecycle: {
+        stages: ['A', 'B'],
+        transitions: [{ from: 'A', to: 'B', gates: [{ id: 'G-01', type: 'bad_type' }] }],
+      },
+    });
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('bad_type'))).toBe(true);
+  });
+
+  test('accepts all valid gate types', () => {
+    const types = [
+      'artifact_approved',
+      'governance_approved',
+      'tool_healthy',
+      'metric_threshold',
+      'manual_confirmation',
+    ];
+    for (const type of types) {
+      const manifest = createMinimalManifest({
+        lifecycle: {
+          stages: ['A', 'B'],
+          transitions: [{ from: 'A', to: 'B', gates: [{ id: 'G-01', type }] }],
+        },
+      });
+      const result = validateManifest(manifest);
+      expect(result.valid).toBe(true);
+    }
+  });
+});
+
+describe('resolveTemplatePaths — extended sections (v1.1.0)', () => {
+  test('resolves governance.policies_file to absolute path', () => {
+    const manifest = createMinimalManifest({
+      governance: {
+        default_mode: 'advisory',
+        policies_file: 'governance-policies.json',
+        gates: { CRITIC_1: { policy: 'TEST', override_allowed: true } },
+      },
+    });
+    const root = '/project/templates/test';
+    const resolved = resolveTemplatePaths(manifest, root);
+
+    expect(resolved.governance).not.toBeNull();
+    expect(resolved.governance.policies_file).toBe(path.join(root, 'governance-policies.json'));
+    expect(resolved.governance.default_mode).toBe('advisory');
+    expect(resolved.governance.gates.CRITIC_1.policy).toBe('TEST');
+  });
+
+  test('defaults governance to null when not present', () => {
+    const manifest = createMinimalManifest();
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.governance).toBeNull();
+  });
+
+  test('passes through phaseTools', () => {
+    const phaseTools = {
+      PHASE_5_EXECUTING: {
+        required: [{ adapter: 'git' }],
+        optional: [],
+      },
+    };
+    const manifest = createMinimalManifest({ phaseTools });
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.phaseTools).toEqual(phaseTools);
+  });
+
+  test('defaults phaseTools to empty object', () => {
+    const manifest = createMinimalManifest();
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.phaseTools).toEqual({});
+  });
+
+  test('passes through lifecycle', () => {
+    const lifecycle = { stages: ['A', 'B'] };
+    const manifest = createMinimalManifest({ lifecycle });
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.lifecycle).toEqual(lifecycle);
+  });
+
+  test('defaults lifecycle to null when not present', () => {
+    const manifest = createMinimalManifest();
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.lifecycle).toBeNull();
+  });
+
+  test('passes through phaseArtifacts', () => {
+    const phaseArtifacts = {
+      PHASE_1: [{ id: 'P1-test', type: 'DOCUMENT', stage: 'REQUIREMENTS', path: 'test.md' }],
+    };
+    const manifest = createMinimalManifest({ phaseArtifacts });
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.phaseArtifacts).toEqual(phaseArtifacts);
+  });
+
+  test('defaults phaseArtifacts to empty object', () => {
+    const manifest = createMinimalManifest();
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.phaseArtifacts).toEqual({});
+  });
+
+  test('passes through phaseLineage', () => {
+    const phaseLineage = { PHASE_2: { consumes: ['PHASE_1'] } };
+    const manifest = createMinimalManifest({ phaseLineage });
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.phaseLineage).toEqual(phaseLineage);
+  });
+
+  test('defaults outputTemplates to empty array', () => {
+    const manifest = createMinimalManifest();
+    const resolved = resolveTemplatePaths(manifest, '/root');
+    expect(resolved.outputTemplates).toEqual([]);
+  });
+});
+
+describe('loadTemplate — SDLC v1.1.0 extended sections', () => {
+  test('SDLC template has governance configuration', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.governance).not.toBeNull();
+    expect(config.governance.default_mode).toBe('advisory');
+    expect(config.governance.policies_file).toContain('governance-policies.json');
+    expect(config.governance.gates.CRITIC_1.policy).toBe('REQUIREMENT_TO_DESIGN');
+    expect(config.governance.gates.CRITIC_2.override_allowed).toBe(false);
+  });
+
+  test('SDLC template has phaseTools for PHASE_5_EXECUTING', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.phaseTools.PHASE_5_EXECUTING).toBeDefined();
+    const p5 = config.phaseTools.PHASE_5_EXECUTING;
+    expect(p5.required.length).toBeGreaterThanOrEqual(2);
+    expect(p5.required.some((t) => t.adapter === 'git')).toBe(true);
+    expect(p5.required.some((t) => t.adapter === 'testing')).toBe(true);
+    expect(p5.optional.some((t) => t.adapter === 'ci')).toBe(true);
+  });
+
+  test('SDLC template has lifecycle with 11 stages', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.lifecycle).not.toBeNull();
+    expect(config.lifecycle.stages).toHaveLength(11);
+    expect(config.lifecycle.stages[0]).toBe('IDEA');
+    expect(config.lifecycle.stages[10]).toBe('IMPROVEMENT');
+  });
+
+  test('SDLC template lifecycle has transitions with gates', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.lifecycle.transitions.length).toBeGreaterThanOrEqual(1);
+    const firstTransition = config.lifecycle.transitions[0];
+    expect(firstTransition.from).toBeDefined();
+    expect(firstTransition.to).toBeDefined();
+    expect(firstTransition.gates.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('SDLC template has phaseArtifacts for all phases', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.phaseArtifacts.PHASE_1.length).toBeGreaterThanOrEqual(1);
+    expect(config.phaseArtifacts.PHASE_2.length).toBeGreaterThanOrEqual(1);
+    expect(config.phaseArtifacts.PHASE_3.length).toBeGreaterThanOrEqual(1);
+    expect(config.phaseArtifacts.PHASE_4.length).toBeGreaterThanOrEqual(1);
+    expect(config.phaseArtifacts.SYNTHESIS.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('SDLC template has phaseLineage', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.phaseLineage.PHASE_2.consumes).toContain('PHASE_1');
+    expect(config.phaseLineage.SYNTHESIS.consumes).toContain('PHASE_1');
+    expect(config.phaseLineage.SYNTHESIS.consumes).toContain('PHASE_4');
+  });
+
+  test('SDLC template has outputTemplates', () => {
+    const config = loadTemplate('sdlc', TEMPLATES_DIR);
+    expect(config.outputTemplates.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test('backward compatibility: v1.0.0 manifest without new sections still loads', () => {
+    // Simulate a v1.0.0 manifest by creating one without the new sections
+    const os = require('node:os');
+    const tmpTemplatesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tpl-compat-'));
+    const tmpTplDir = path.join(tmpTemplatesDir, 'legacy');
+
+    try {
+      fs.mkdirSync(tmpTplDir, { recursive: true });
+      const legacyManifest = createMinimalManifest();
+      // Explicitly ensure no v1.1.0 sections
+      delete legacyManifest.governance;
+      delete legacyManifest.phaseTools;
+      delete legacyManifest.lifecycle;
+      delete legacyManifest.phaseArtifacts;
+      delete legacyManifest.phaseLineage;
+      fs.writeFileSync(path.join(tmpTplDir, 'manifest.json'), JSON.stringify(legacyManifest));
+
+      const config = loadTemplate('legacy', tmpTemplatesDir);
+      expect(config.name).toBe('test-template');
+      expect(config.governance).toBeNull();
+      expect(config.phaseTools).toEqual({});
+      expect(config.lifecycle).toBeNull();
+      expect(config.phaseArtifacts).toEqual({});
+      expect(config.phaseLineage).toEqual({});
+    } finally {
+      fs.rmSync(tmpTemplatesDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## M9: Template System Extensions

Implements all 7 open issues for milestone M9, extending the template system to v1.1.0 with governance, tooling, and lifecycle support.

### Changes

| Issue | Description |
|-------|-------------|
| #389 | **Schema v1.1.0** — Added `governance`, `phaseTools`, `lifecycle`, `phaseArtifacts`, `phaseLineage`, `outputTemplates`, `decisionsDir`, `decisionIndexSeed` properties |
| #385 | **Governance references** — Advisory/enforcing/off modes, policy file reference, 5 gate mappings (CRITIC_1–4, SPRINT_GATE) |
| #386 | **Tool requirements** — Per-phase required/optional adapter arrays for all 5 phases |
| #387 | **Lifecycle rules** — 11 stages (IDEA → IMPROVEMENT), 6 transitions with typed gate conditions |
| #388 | **Template loader** — Extended validation and `resolveTemplatePaths` for all new sections |
| #390 | **Transpiler** — Generates phase artifacts, tool requirements, governance, and lifecycle context into Copilot instructions |
| #391 | **Unit tests** — 34 new tests covering validation, path resolution, SDLC integration, and backward compatibility |

### Test Results

- **83/83 tests passing** (49 original + 34 new)
- Transpiler generates all 3 targets successfully (copilot: 40 files, claude: 40 files, openai: 2 files)
- Full backward compatibility with v1.0.0 manifests verified

### Files Changed

- `platform/schema/template-manifest.schema.json` — Schema definitions
- `platform/engine/template-loader.ts` — Validation + resolution logic
- `templates/sdlc/manifest.json` — SDLC manifest with new sections
- `scripts/generate-platform.js` — Transpiler extended output
- `tests/unit/template-loader.test.js` — 34 new test cases

Closes #385, #386, #387, #388, #389, #390, #391