### PR TITLE
feat(M23): implement Durable Persistence Layer (#322-#328)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
+        "better-sqlite3": "^12.8.0",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -19,6 +20,7 @@
         "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^8.57.1",
         "@playwright/test": "^1.58.2",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.19.37",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -31,7 +33,6 @@
         "jsdom": "^28.1.0",
         "lighthouse": "^12.6.0",
         "lint-staged": "^16.3.3",
-        "msw-storybook-addon": "^2.0.6",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
@@ -1066,6 +1067,7 @@
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -1077,6 +1079,7 @@
       "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1100,6 +1103,7 @@
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -1129,6 +1133,7 @@
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -1145,6 +1150,7 @@
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -1156,6 +1162,7 @@
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -1243,6 +1250,7 @@
       "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -1317,6 +1325,7 @@
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@open-draft/logger": {
@@ -1325,6 +1334,7 @@
       "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "is-node-process": "^1.2.0",
@@ -1337,6 +1347,7 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@opentelemetry/api": {
@@ -2402,6 +2413,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2492,6 +2513,7 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/tedious": {
@@ -3215,6 +3237,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
@@ -3225,6 +3267,20 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3233,6 +3289,40 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/body-parser": {
@@ -3280,6 +3370,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -3366,6 +3480,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/chrome-launcher": {
       "version": "1.2.1",
@@ -3525,6 +3645,7 @@
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 12"
@@ -3808,6 +3929,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3863,7 +4008,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3984,7 +4128,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4505,6 +4648,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4726,6 +4878,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4885,6 +5043,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5001,6 +5165,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -5127,6 +5297,7 @@
       "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -5188,6 +5359,7 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/hono": {
@@ -5309,6 +5481,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5389,6 +5581,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/intl-messageformat": {
@@ -5502,7 +5700,9 @@
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6596,6 +6796,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -6612,11 +6824,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
     "node_modules/module-details-from-path": {
@@ -6639,6 +6866,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
@@ -6678,25 +6906,13 @@
         }
       }
     },
-    "node_modules/msw-storybook-addon": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-2.0.6.tgz",
-      "integrity": "sha512-ExCwDbcJoM2V3iQU+fZNp+axVfNc7DWMRh4lyTXebDO8IbpUNYKGFUrA8UqaeWiRGKVuS7+fU+KXEa9b0OP6uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-node-process": "^1.0.1"
-      },
-      "peerDependencies": {
-        "msw": "^2.0.0"
-      }
-    },
     "node_modules/msw/node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -6712,6 +6928,7 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/msw/node_modules/type-fest": {
@@ -6720,6 +6937,7 @@
       "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -6737,6 +6955,7 @@
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -6760,6 +6979,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6785,6 +7010,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -6882,6 +7119,7 @@
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/p-limit": {
@@ -7250,6 +7488,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7367,7 +7674,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7490,6 +7796,30 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -7621,6 +7951,7 @@
       "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/reusify": {
@@ -7746,7 +8077,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -7820,7 +8150,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8007,6 +8336,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8181,13 +8555,13 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -8316,6 +8690,7 @@
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20"
@@ -8624,6 +8999,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8717,6 +9104,7 @@
       "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
@@ -8736,7 +9124,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {
@@ -9210,6 +9597,7 @@
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^8.57.1",
     "@playwright/test": "^1.58.2",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.19.37",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
@@ -70,6 +71,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
+    "better-sqlite3": "^12.8.0",
     "tsx": "^4.21.0"
   },
   "lint-staged": {

--- a/platform/engine/persistence/factory.ts
+++ b/platform/engine/persistence/factory.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+/* ── StorageProvider Factory (M23-005 prep) ───────────────────── *
+ * Selects and initializes the correct StorageProvider based on    *
+ * configuration.  STORAGE_PROVIDER env var: "file" | "sqlite".   *
+ * ─────────────────────────────────────────────────────────────── */
+
+import type { StorageProvider } from './storage-provider';
+import { FileStorageProvider } from './file-provider';
+import { SQLiteStorageProvider } from './sqlite-provider';
+
+export type ProviderType = 'file' | 'sqlite';
+
+export interface StorageProviderConfig {
+  provider?: ProviderType;
+  /** Base path for FileStorageProvider. */
+  basePath?: string;
+  /** Database file path for SQLiteStorageProvider. */
+  dbPath?: string;
+}
+
+/**
+ * Create and initialize a StorageProvider from configuration.
+ * Reads STORAGE_PROVIDER env var if config.provider is not set.
+ */
+export async function createStorageProvider(
+  config?: StorageProviderConfig
+): Promise<StorageProvider> {
+  const type: ProviderType =
+    config?.provider || (process.env.STORAGE_PROVIDER as ProviderType) || 'file';
+
+  let provider: StorageProvider;
+
+  switch (type) {
+    case 'sqlite':
+      provider = new SQLiteStorageProvider({ dbPath: config?.dbPath });
+      break;
+    case 'file':
+    default:
+      provider = new FileStorageProvider({ basePath: config?.basePath });
+      break;
+  }
+
+  await provider.initialize();
+  return provider;
+}

--- a/platform/engine/persistence/file-provider.ts
+++ b/platform/engine/persistence/file-provider.ts
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+/* ── FileStorageProvider (M23-002) ────────────────────────────── *
+ * Wraps the existing FileStore behind the StorageProvider         *
+ * interface.  Collections map to subdirectories under a           *
+ * configurable base path.  Documents are stored as JSON files.    *
+ * Preserves atomic write (temp-then-rename) and backup-on-write   *
+ * semantics from the original FileStore.                          *
+ * ─────────────────────────────────────────────────────────────── */
+
+import fs from 'fs';
+import path from 'path';
+import type {
+  StorageProvider,
+  Document,
+  Filter,
+  Query,
+  Operation,
+  HealthStatus,
+  StorageMetrics,
+} from './storage-provider';
+
+const BACKUPS_DIR = '.backups';
+const MAX_BACKUPS = 10;
+const MAX_LATENCY_SAMPLES = 200;
+
+export interface FileStorageProviderOptions {
+  /** Base directory for all collections (default: process.cwd()). */
+  basePath?: string;
+}
+
+export class FileStorageProvider implements StorageProvider {
+  readonly name = 'file';
+  private _basePath: string;
+  private _metrics: StorageMetrics = {
+    reads: 0,
+    writes: 0,
+    deletes: 0,
+    errors: 0,
+    readLatencies: [],
+    writeLatencies: [],
+  };
+
+  constructor(opts?: FileStorageProviderOptions) {
+    this._basePath = opts?.basePath || process.cwd();
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────
+
+  private _collectionDir(collection: string): string {
+    return path.join(this._basePath, collection);
+  }
+
+  private _docPath(collection: string, id: string): string {
+    // Sanitize id to prevent path traversal
+    const safeId = path.basename(id);
+    return path.join(this._collectionDir(collection), `${safeId}.json`);
+  }
+
+  private _ensureDir(dirPath: string): void {
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    }
+  }
+
+  private _createBackup(filePath: string): void {
+    if (!fs.existsSync(filePath)) return;
+    const dir = path.dirname(filePath);
+    const base = path.basename(filePath);
+    const bkDir = path.join(dir, BACKUPS_DIR, base);
+    if (!fs.existsSync(bkDir)) fs.mkdirSync(bkDir, { recursive: true });
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    fs.copyFileSync(filePath, path.join(bkDir, stamp));
+
+    // Prune oldest beyond limit
+    const files = fs.readdirSync(bkDir).sort();
+    while (files.length > MAX_BACKUPS) {
+      const oldest = files.shift()!;
+      try {
+        fs.unlinkSync(path.join(bkDir, oldest));
+      } catch {
+        /* ignore cleanup errors */
+      }
+    }
+  }
+
+  private _atomicWrite(filePath: string, data: string): void {
+    const dir = path.dirname(filePath);
+    this._ensureDir(dir);
+    this._createBackup(filePath);
+    const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+    try {
+      fs.writeFileSync(tmpPath, data, 'utf8');
+      fs.renameSync(tmpPath, filePath);
+    } catch (err) {
+      try {
+        fs.unlinkSync(tmpPath);
+      } catch {
+        /* ignore cleanup */
+      }
+      throw err;
+    }
+  }
+
+  private _recordLatency(arr: number[], ms: number): void {
+    arr.push(ms);
+    if (arr.length > MAX_LATENCY_SAMPLES) arr.shift();
+  }
+
+  // ── StorageProvider implementation ─────────────────────────────
+
+  async initialize(): Promise<void> {
+    this._ensureDir(this._basePath);
+  }
+
+  async close(): Promise<void> {
+    // No resources to release for file-based storage.
+  }
+
+  async read(collection: string, id: string): Promise<Document | null> {
+    const start = Date.now();
+    try {
+      const fp = this._docPath(collection, id);
+      if (!fs.existsSync(fp)) return null;
+      const raw = fs.readFileSync(fp, 'utf8');
+      this._metrics.reads++;
+      this._recordLatency(this._metrics.readLatencies, Date.now() - start);
+      return JSON.parse(raw) as Document;
+    } catch {
+      this._metrics.errors++;
+      return null;
+    }
+  }
+
+  async write(collection: string, id: string, data: Document): Promise<void> {
+    const start = Date.now();
+    try {
+      const fp = this._docPath(collection, id);
+      this._atomicWrite(fp, JSON.stringify(data, null, 2));
+      this._metrics.writes++;
+      this._recordLatency(this._metrics.writeLatencies, Date.now() - start);
+    } catch (err) {
+      this._metrics.errors++;
+      throw err;
+    }
+  }
+
+  async delete(collection: string, id: string): Promise<void> {
+    try {
+      const fp = this._docPath(collection, id);
+      if (fs.existsSync(fp)) {
+        this._createBackup(fp);
+        fs.unlinkSync(fp);
+      }
+      this._metrics.deletes++;
+    } catch (err) {
+      this._metrics.errors++;
+      throw err;
+    }
+  }
+
+  async list(collection: string, filter?: Filter): Promise<Document[]> {
+    const start = Date.now();
+    try {
+      const dir = this._collectionDir(collection);
+      if (!fs.existsSync(dir)) return [];
+
+      const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+      let docs: Document[] = [];
+
+      for (const file of files) {
+        try {
+          const raw = fs.readFileSync(path.join(dir, file), 'utf8');
+          docs.push(JSON.parse(raw) as Document);
+        } catch {
+          /* skip malformed files */
+        }
+      }
+
+      docs = this._applyFilter(docs, filter);
+      this._metrics.reads++;
+      this._recordLatency(this._metrics.readLatencies, Date.now() - start);
+      return docs;
+    } catch {
+      this._metrics.errors++;
+      return [];
+    }
+  }
+
+  async transaction(ops: Operation[]): Promise<void> {
+    // File-based: execute sequentially. No true atomicity — best effort.
+    // Back up all targets first for manual recovery if partial failure occurs.
+    for (const op of ops) {
+      if (op.type === 'write' && op.data) {
+        await this.write(op.collection, op.id, op.data);
+      } else if (op.type === 'delete') {
+        await this.delete(op.collection, op.id);
+      }
+    }
+  }
+
+  async query(collection: string, q: Query): Promise<Document[]> {
+    let docs = await this.list(collection, q);
+
+    if (q.text) {
+      const term = q.text.toLowerCase();
+      docs = docs.filter((doc) => JSON.stringify(doc).toLowerCase().includes(term));
+    }
+
+    return docs;
+  }
+
+  async health(): Promise<HealthStatus> {
+    const start = Date.now();
+    try {
+      // Probe: can we read the base directory?
+      fs.accessSync(this._basePath, fs.constants.R_OK | fs.constants.W_OK);
+      return {
+        status: 'healthy',
+        provider: this.name,
+        latencyMs: Date.now() - start,
+      };
+    } catch {
+      return {
+        status: 'unhealthy',
+        provider: this.name,
+        latencyMs: Date.now() - start,
+        details: { error: 'Base path not accessible' },
+      };
+    }
+  }
+
+  metrics(): StorageMetrics {
+    return { ...this._metrics };
+  }
+
+  // ── Filter logic ──────────────────────────────────────────────
+
+  private _applyFilter(docs: Document[], filter?: Filter): Document[] {
+    if (!filter) return docs;
+
+    let result = docs;
+
+    if (filter.where) {
+      const entries = Object.entries(filter.where);
+      result = result.filter((doc) => entries.every(([key, val]) => doc[key] === val));
+    }
+
+    if (filter.orderBy) {
+      const { field, direction } = filter.orderBy;
+      result.sort((a, b) => {
+        const va = a[field];
+        const vb = b[field];
+        if (va === vb) return 0;
+        if (va == null) return 1;
+        if (vb == null) return -1;
+        const cmp = va < vb ? -1 : 1;
+        return direction === 'desc' ? -cmp : cmp;
+      });
+    }
+
+    if (filter.offset) {
+      result = result.slice(filter.offset);
+    }
+
+    if (filter.limit != null) {
+      result = result.slice(0, filter.limit);
+    }
+
+    return result;
+  }
+}

--- a/platform/engine/persistence/index.ts
+++ b/platform/engine/persistence/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+export type {
+  StorageProvider,
+  Document,
+  Filter,
+  Query,
+  Operation,
+  HealthStatus,
+  StorageMetrics,
+} from './storage-provider';
+export { FileStorageProvider } from './file-provider';
+export { SQLiteStorageProvider } from './sqlite-provider';
+export { createStorageProvider } from './factory';
+export type { ProviderType, StorageProviderConfig } from './factory';

--- a/platform/engine/persistence/sqlite-provider.ts
+++ b/platform/engine/persistence/sqlite-provider.ts
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+/* ── SQLiteStorageProvider (M23-003) ──────────────────────────── *
+ * Database-backed StorageProvider using better-sqlite3.           *
+ * Zero-config single-file database with WAL mode for concurrent   *
+ * read performance.  JSON column for flexible document storage.   *
+ * Auto-creates tables per collection on first access.             *
+ * ─────────────────────────────────────────────────────────────── */
+
+import path from 'path';
+import fs from 'fs';
+import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import type {
+  StorageProvider,
+  Document,
+  Filter,
+  Query,
+  Operation,
+  HealthStatus,
+  StorageMetrics,
+} from './storage-provider';
+
+const MAX_LATENCY_SAMPLES = 200;
+
+// Allowlist of safe collection names (alphanumeric + underscore + hyphen)
+const COLLECTION_RE = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/;
+
+export interface SQLiteStorageProviderOptions {
+  /** Path to the SQLite database file (default: .agentic/data.db). */
+  dbPath?: string;
+}
+
+export class SQLiteStorageProvider implements StorageProvider {
+  readonly name = 'sqlite';
+  private _dbPath: string;
+  private _db: DatabaseType | null = null;
+  private _ensuredTables = new Set<string>();
+  private _metrics: StorageMetrics = {
+    reads: 0,
+    writes: 0,
+    deletes: 0,
+    errors: 0,
+    readLatencies: [],
+    writeLatencies: [],
+  };
+
+  constructor(opts?: SQLiteStorageProviderOptions) {
+    this._dbPath = opts?.dbPath || path.join(process.cwd(), '.agentic', 'data.db');
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────
+
+  private _getDb(): DatabaseType {
+    if (!this._db) {
+      throw new Error('SQLiteStorageProvider not initialized — call initialize() first');
+    }
+    return this._db;
+  }
+
+  private _tableName(collection: string): string {
+    if (!COLLECTION_RE.test(collection)) {
+      throw new Error(`Invalid collection name: ${collection}`);
+    }
+    return `col_${collection.replace(/-/g, '_')}`;
+  }
+
+  private _ensureTable(collection: string): void {
+    if (this._ensuredTables.has(collection)) return;
+    const table = this._tableName(collection);
+    const db = this._getDb();
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS "${table}" (
+        id TEXT PRIMARY KEY NOT NULL,
+        data TEXT NOT NULL,
+        status TEXT GENERATED ALWAYS AS (json_extract(data, '$.status')) STORED,
+        type TEXT GENERATED ALWAYS AS (json_extract(data, '$.type')) STORED,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )
+    `);
+    // Create indexes for common query patterns
+    db.exec(`CREATE INDEX IF NOT EXISTS "idx_${table}_status" ON "${table}" (status)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS "idx_${table}_type" ON "${table}" (type)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS "idx_${table}_updated" ON "${table}" (updated_at)`);
+    this._ensuredTables.add(collection);
+  }
+
+  private _recordLatency(arr: number[], ms: number): void {
+    arr.push(ms);
+    if (arr.length > MAX_LATENCY_SAMPLES) arr.shift();
+  }
+
+  // ── StorageProvider implementation ─────────────────────────────
+
+  async initialize(): Promise<void> {
+    const dir = path.dirname(this._dbPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    this._db = new Database(this._dbPath);
+    this._db.pragma('journal_mode = WAL');
+    this._db.pragma('foreign_keys = ON');
+    this._db.pragma('busy_timeout = 5000');
+  }
+
+  async close(): Promise<void> {
+    if (this._db) {
+      this._db.close();
+      this._db = null;
+      this._ensuredTables.clear();
+    }
+  }
+
+  async read(collection: string, id: string): Promise<Document | null> {
+    const start = Date.now();
+    try {
+      this._ensureTable(collection);
+      const table = this._tableName(collection);
+      const row = this._getDb().prepare(`SELECT data FROM "${table}" WHERE id = ?`).get(id) as
+        | { data: string }
+        | undefined;
+
+      this._metrics.reads++;
+      this._recordLatency(this._metrics.readLatencies, Date.now() - start);
+      return row ? (JSON.parse(row.data) as Document) : null;
+    } catch {
+      this._metrics.errors++;
+      return null;
+    }
+  }
+
+  async write(collection: string, id: string, data: Document): Promise<void> {
+    const start = Date.now();
+    try {
+      this._ensureTable(collection);
+      const table = this._tableName(collection);
+      const json = JSON.stringify(data);
+      this._getDb()
+        .prepare(
+          `INSERT INTO "${table}" (id, data, updated_at) VALUES (?, ?, datetime('now'))
+           ON CONFLICT(id) DO UPDATE SET data = excluded.data, updated_at = datetime('now')`
+        )
+        .run(id, json);
+
+      this._metrics.writes++;
+      this._recordLatency(this._metrics.writeLatencies, Date.now() - start);
+    } catch (err) {
+      this._metrics.errors++;
+      throw err;
+    }
+  }
+
+  async delete(collection: string, id: string): Promise<void> {
+    try {
+      this._ensureTable(collection);
+      const table = this._tableName(collection);
+      this._getDb().prepare(`DELETE FROM "${table}" WHERE id = ?`).run(id);
+      this._metrics.deletes++;
+    } catch (err) {
+      this._metrics.errors++;
+      throw err;
+    }
+  }
+
+  async list(collection: string, filter?: Filter): Promise<Document[]> {
+    const start = Date.now();
+    try {
+      this._ensureTable(collection);
+      const table = this._tableName(collection);
+      const { clause, params } = this._buildWhere(filter);
+      const orderBy = this._buildOrderBy(filter);
+      const limitOffset = this._buildLimitOffset(filter);
+
+      const sql = `SELECT data FROM "${table}"${clause}${orderBy}${limitOffset}`;
+      const rows = this._getDb()
+        .prepare(sql)
+        .all(...params) as { data: string }[];
+      const docs = rows.map((r) => JSON.parse(r.data) as Document);
+
+      this._metrics.reads++;
+      this._recordLatency(this._metrics.readLatencies, Date.now() - start);
+      return docs;
+    } catch {
+      this._metrics.errors++;
+      return [];
+    }
+  }
+
+  async transaction(ops: Operation[]): Promise<void> {
+    const db = this._getDb();
+    const txn = db.transaction(() => {
+      for (const op of ops) {
+        if (op.type === 'write' && op.data) {
+          this._ensureTable(op.collection);
+          const table = this._tableName(op.collection);
+          const json = JSON.stringify(op.data);
+          db.prepare(
+            `INSERT INTO "${table}" (id, data, updated_at) VALUES (?, ?, datetime('now'))
+             ON CONFLICT(id) DO UPDATE SET data = excluded.data, updated_at = datetime('now')`
+          ).run(op.id, json);
+          this._metrics.writes++;
+        } else if (op.type === 'delete') {
+          this._ensureTable(op.collection);
+          const table = this._tableName(op.collection);
+          db.prepare(`DELETE FROM "${table}" WHERE id = ?`).run(op.id);
+          this._metrics.deletes++;
+        }
+      }
+    });
+    txn();
+  }
+
+  async query(collection: string, q: Query): Promise<Document[]> {
+    let docs = await this.list(collection, q);
+
+    if (q.text) {
+      const term = q.text.toLowerCase();
+      docs = docs.filter((doc) => JSON.stringify(doc).toLowerCase().includes(term));
+    }
+
+    return docs;
+  }
+
+  async health(): Promise<HealthStatus> {
+    const start = Date.now();
+    try {
+      const db = this._getDb();
+      db.prepare('SELECT 1').get();
+      return {
+        status: 'healthy',
+        provider: this.name,
+        latencyMs: Date.now() - start,
+        details: { dbPath: this._dbPath, walMode: true },
+      };
+    } catch {
+      return {
+        status: 'unhealthy',
+        provider: this.name,
+        latencyMs: Date.now() - start,
+        details: { error: 'Database not accessible' },
+      };
+    }
+  }
+
+  metrics(): StorageMetrics {
+    return { ...this._metrics };
+  }
+
+  // ── SQL builders ──────────────────────────────────────────────
+
+  private _buildWhere(filter?: Filter): { clause: string; params: unknown[] } {
+    if (!filter?.where || Object.keys(filter.where).length === 0) {
+      return { clause: '', params: [] };
+    }
+
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    for (const [key, val] of Object.entries(filter.where)) {
+      if (key === 'id') {
+        conditions.push('id = ?');
+        params.push(val);
+      } else if (key === 'status') {
+        conditions.push('status = ?');
+        params.push(val);
+      } else if (key === 'type') {
+        conditions.push('type = ?');
+        params.push(val);
+      } else {
+        // Generic JSON field extraction
+        conditions.push(`json_extract(data, '$.${key}') = ?`);
+        params.push(val);
+      }
+    }
+
+    return { clause: ` WHERE ${conditions.join(' AND ')}`, params };
+  }
+
+  private _buildOrderBy(filter?: Filter): string {
+    if (!filter?.orderBy) return '';
+    const dir = filter.orderBy.direction === 'desc' ? 'DESC' : 'ASC';
+    const field = filter.orderBy.field;
+    if (field === 'id') return ` ORDER BY id ${dir}`;
+    if (field === 'updated_at') return ` ORDER BY updated_at ${dir}`;
+    return ` ORDER BY json_extract(data, '$.${field}') ${dir}`;
+  }
+
+  private _buildLimitOffset(filter?: Filter): string {
+    let sql = '';
+    if (filter?.limit != null) {
+      sql += ` LIMIT ${Number(filter.limit)}`;
+    } else if (filter?.offset) {
+      // SQLite requires LIMIT before OFFSET; use -1 for unlimited
+      sql += ' LIMIT -1';
+    }
+    if (filter?.offset) sql += ` OFFSET ${Number(filter.offset)}`;
+    return sql;
+  }
+}

--- a/platform/engine/persistence/storage-provider.ts
+++ b/platform/engine/persistence/storage-provider.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+/* ── StorageProvider Interface (M23-001) ──────────────────────── *
+ * Pluggable persistence abstraction for the SDLC platform.       *
+ * Implementations: FileStorageProvider (default), SQLiteProvider. *
+ * Collections map to domain concepts: sessions, decisions,       *
+ * questionnaires, commands, artifacts, audit-events, metrics.    *
+ * ─────────────────────────────────────────────────────────────── */
+
+/** A stored document — arbitrary JSON-serializable data with an id. */
+export interface Document {
+  id: string;
+  [key: string]: unknown;
+}
+
+/** Filter for list operations. */
+export interface Filter {
+  /** Match field values exactly. */
+  where?: Record<string, unknown>;
+  /** Maximum number of results. */
+  limit?: number;
+  /** Number of results to skip. */
+  offset?: number;
+  /** Sort field and direction. */
+  orderBy?: { field: string; direction: 'asc' | 'desc' };
+}
+
+/** Query extends Filter with text search. */
+export interface Query extends Filter {
+  /** Full-text search term (provider-specific behavior). */
+  text?: string;
+}
+
+/** A single write operation for transaction batches. */
+export interface Operation {
+  type: 'write' | 'delete';
+  collection: string;
+  id: string;
+  /** Required for 'write' operations. */
+  data?: Document;
+}
+
+/** Health status returned by the provider. */
+export interface HealthStatus {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  provider: string;
+  /** Latency of a simple read check in milliseconds. */
+  latencyMs: number;
+  details?: Record<string, unknown>;
+}
+
+/** Storage operation metrics for observability. */
+export interface StorageMetrics {
+  reads: number;
+  writes: number;
+  deletes: number;
+  errors: number;
+  /** Read latency samples in ms (most recent, capped). */
+  readLatencies: number[];
+  /** Write latency samples in ms (most recent, capped). */
+  writeLatencies: number[];
+}
+
+/**
+ * StorageProvider — the pluggable persistence interface.
+ *
+ * All methods are async to support both file-based and database-backed
+ * implementations without forcing callers to know the underlying store.
+ */
+export interface StorageProvider {
+  /** Human-readable provider name (e.g. "file", "sqlite"). */
+  readonly name: string;
+
+  // ── Document operations ──────────────────────────────────────
+
+  /** Read a single document by collection + id. Returns null if missing. */
+  read(collection: string, id: string): Promise<Document | null>;
+
+  /** Write (create or update) a document. */
+  write(collection: string, id: string, data: Document): Promise<void>;
+
+  /** Delete a document. No-op if it doesn't exist. */
+  delete(collection: string, id: string): Promise<void>;
+
+  /** List documents in a collection, optionally filtered. */
+  list(collection: string, filter?: Filter): Promise<Document[]>;
+
+  // ── Batch / atomic operations ────────────────────────────────
+
+  /** Execute multiple operations atomically (all-or-nothing where supported). */
+  transaction(ops: Operation[]): Promise<void>;
+
+  // ── Query ────────────────────────────────────────────────────
+
+  /** Query documents with filtering + optional text search. */
+  query(collection: string, query: Query): Promise<Document[]>;
+
+  // ── Lifecycle ────────────────────────────────────────────────
+
+  /** Initialize the provider (create dirs, open DB, run migrations). */
+  initialize(): Promise<void>;
+
+  /** Gracefully close the provider (flush, close connections). */
+  close(): Promise<void>;
+
+  /** Health check for observability. */
+  health(): Promise<HealthStatus>;
+
+  /** Cumulative operation metrics. */
+  metrics(): StorageMetrics;
+}

--- a/scripts/migrate-storage.ts
+++ b/scripts/migrate-storage.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+/**
+ * Storage migration utility (M23-006).
+ *
+ * Migrates data between StorageProvider implementations (file ↔ sqlite).
+ * Reads all documents from the source, writes them to the target, and
+ * validates that the migration is complete.
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-storage.ts --from file --to sqlite [--dry-run]
+ *   npx tsx scripts/migrate-storage.ts --from sqlite --to file [--dry-run]
+ *
+ * Options:
+ *   --from <provider>   Source provider type: "file" or "sqlite"
+ *   --to <provider>     Target provider type: "file" or "sqlite"
+ *   --dry-run           Show what would be migrated without writing
+ *   --source-path <p>   Override path for source provider
+ *   --target-path <p>   Override path for target provider
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import {
+  createStorageProvider,
+  type StorageProvider,
+  type ProviderType,
+  type Document,
+} from '../platform/engine/persistence';
+
+/* ── CLI argument parsing ──────────────────────────────────────── */
+
+interface MigrateOptions {
+  from: ProviderType;
+  to: ProviderType;
+  dryRun: boolean;
+  sourcePath?: string;
+  targetPath?: string;
+}
+
+function parseArgs(argv: string[]): MigrateOptions {
+  const opts: MigrateOptions = { from: 'file', to: 'sqlite', dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--from':
+        opts.from = argv[++i] as ProviderType;
+        break;
+      case '--to':
+        opts.to = argv[++i] as ProviderType;
+        break;
+      case '--dry-run':
+        opts.dryRun = true;
+        break;
+      case '--source-path':
+        opts.sourcePath = argv[++i];
+        break;
+      case '--target-path':
+        opts.targetPath = argv[++i];
+        break;
+    }
+  }
+  if (!['file', 'sqlite'].includes(opts.from) || !['file', 'sqlite'].includes(opts.to)) {
+    throw new Error('--from and --to must be "file" or "sqlite"');
+  }
+  if (opts.from === opts.to) {
+    throw new Error('Source and target providers must be different');
+  }
+  return opts;
+}
+
+/* ── Collection discovery ──────────────────────────────────────── */
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+/** Discover collection names from a file-based provider. */
+function discoverFileCollections(basePath: string): string[] {
+  if (!fs.existsSync(basePath)) return [];
+  return fs
+    .readdirSync(basePath, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+    .map((d) => d.name);
+}
+
+/** Discover collection names from a SQLite provider. */
+function discoverSqliteCollections(provider: StorageProvider): string[] {
+  // SQLite tables are named col_{collection} — query sqlite_master
+  const db = (provider as Record<string, unknown>)._db as {
+    prepare(sql: string): { all(): Array<{ name: string }> };
+  } | null;
+  if (!db) return [];
+  const rows = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'col_%'")
+    .all();
+  return rows.map((r) => r.name.replace(/^col_/, ''));
+}
+
+function discoverCollections(
+  provider: StorageProvider,
+  providerType: ProviderType,
+  basePath?: string
+): string[] {
+  if (providerType === 'file') {
+    const bp = basePath || path.join(PROJECT_ROOT, '.agentic', 'storage');
+    return discoverFileCollections(bp);
+  }
+  return discoverSqliteCollections(provider);
+}
+
+/* ── Content hash ──────────────────────────────────────────────── */
+
+function hashDocument(doc: Document): string {
+  const sorted = JSON.stringify(doc, Object.keys(doc).sort());
+  return crypto.createHash('sha256').update(sorted).digest('hex').slice(0, 16);
+}
+
+/* ── Migration ─────────────────────────────────────────────────── */
+
+interface MigrationResult {
+  collection: string;
+  documentCount: number;
+  skipped: number;
+  errors: string[];
+}
+
+async function migrateCollection(
+  source: StorageProvider,
+  target: StorageProvider,
+  collection: string,
+  dryRun: boolean
+): Promise<MigrationResult> {
+  const result: MigrationResult = { collection, documentCount: 0, skipped: 0, errors: [] };
+
+  const docs = await source.list(collection);
+  result.documentCount = docs.length;
+
+  if (dryRun) {
+    console.log(`  [DRY RUN] ${collection}: ${docs.length} document(s) would be migrated`);
+    return result;
+  }
+
+  for (const doc of docs) {
+    try {
+      await target.write(collection, doc.id, doc);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push(`${collection}/${doc.id}: ${msg}`);
+    }
+  }
+
+  return result;
+}
+
+async function validateMigration(
+  source: StorageProvider,
+  target: StorageProvider,
+  collections: string[]
+): Promise<{ valid: boolean; issues: string[] }> {
+  const issues: string[] = [];
+
+  for (const collection of collections) {
+    const sourceDocs = await source.list(collection);
+    const targetDocs = await target.list(collection);
+
+    if (sourceDocs.length !== targetDocs.length) {
+      issues.push(
+        `${collection}: count mismatch — source=${sourceDocs.length}, target=${targetDocs.length}`
+      );
+      continue;
+    }
+
+    const targetMap = new Map(targetDocs.map((d) => [d.id, d]));
+    for (const srcDoc of sourceDocs) {
+      const tgtDoc = targetMap.get(srcDoc.id);
+      if (!tgtDoc) {
+        issues.push(`${collection}/${srcDoc.id}: missing in target`);
+        continue;
+      }
+      const srcHash = hashDocument(srcDoc);
+      const tgtHash = hashDocument(tgtDoc);
+      if (srcHash !== tgtHash) {
+        issues.push(`${collection}/${srcDoc.id}: content hash mismatch`);
+      }
+    }
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+/* ── Main ──────────────────────────────────────────────────────── */
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+
+  console.log(`\nStorage Migration: ${opts.from} → ${opts.to}`);
+  if (opts.dryRun) console.log('  Mode: DRY RUN (no writes)\n');
+  else console.log('');
+
+  const sourceConfig = {
+    provider: opts.from,
+    basePath:
+      opts.sourcePath ||
+      (opts.from === 'file' ? path.join(PROJECT_ROOT, '.agentic', 'storage') : undefined),
+    dbPath:
+      opts.sourcePath ||
+      (opts.from === 'sqlite' ? path.join(PROJECT_ROOT, '.agentic', 'data.db') : undefined),
+  };
+  const targetConfig = {
+    provider: opts.to,
+    basePath:
+      opts.targetPath ||
+      (opts.to === 'file' ? path.join(PROJECT_ROOT, '.agentic', 'storage') : undefined),
+    dbPath:
+      opts.targetPath ||
+      (opts.to === 'sqlite' ? path.join(PROJECT_ROOT, '.agentic', 'data.db') : undefined),
+  };
+
+  const source = await createStorageProvider(sourceConfig);
+  const target = await createStorageProvider(targetConfig);
+
+  try {
+    const collections = discoverCollections(
+      source,
+      opts.from,
+      opts.from === 'file' ? sourceConfig.basePath : undefined
+    );
+
+    if (collections.length === 0) {
+      console.log('No collections found in source. Nothing to migrate.');
+      return;
+    }
+
+    console.log(`Found ${collections.length} collection(s): ${collections.join(', ')}\n`);
+
+    const results: MigrationResult[] = [];
+    let totalDocs = 0;
+    let totalErrors = 0;
+
+    for (const collection of collections) {
+      const result = await migrateCollection(source, target, collection, opts.dryRun);
+      results.push(result);
+      totalDocs += result.documentCount;
+      totalErrors += result.errors.length;
+      if (!opts.dryRun) {
+        const status = result.errors.length ? '⚠' : '✓';
+        console.log(
+          `  ${status} ${collection}: ${result.documentCount} doc(s), ${result.errors.length} error(s)`
+        );
+      }
+    }
+
+    console.log(`\nTotal: ${totalDocs} document(s) across ${collections.length} collection(s)`);
+    if (totalErrors > 0) {
+      console.log(`\n⚠ ${totalErrors} error(s):`);
+      for (const r of results) {
+        for (const e of r.errors) console.log(`  - ${e}`);
+      }
+    }
+
+    if (!opts.dryRun) {
+      console.log('\nValidating migration...');
+      const validation = await validateMigration(source, target, collections);
+      if (validation.valid) {
+        console.log('✓ Migration validated — all documents match.');
+      } else {
+        console.log(`⚠ Validation found ${validation.issues.length} issue(s):`);
+        for (const issue of validation.issues) console.log(`  - ${issue}`);
+        process.exitCode = 1;
+      }
+    }
+  } finally {
+    await source.close();
+    await target.close();
+  }
+}
+
+main().catch((err: Error) => {
+  console.error(`Migration failed: ${err.message}`);
+  process.exitCode = 1;
+});

--- a/src/webapp/config.ts
+++ b/src/webapp/config.ts
@@ -39,3 +39,12 @@ export const METRICS_FLUSH_INTERVAL_MS = 60000;
 export const SNAPSHOT_SYNC_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 export const RATE_LIMIT_WINDOW_MS = 60_000;
 export const RATE_LIMIT_MAX = 30;
+
+/* ── Persistence layer (M23-005) ──────────────────────────────── */
+export type StorageProviderType = 'file' | 'sqlite';
+export const STORAGE_PROVIDER: StorageProviderType = (() => {
+  const v = process.env.STORAGE_PROVIDER;
+  if (v === 'sqlite') return 'sqlite';
+  return 'file';
+})();
+export const STORAGE_PATH: string | undefined = process.env.STORAGE_PATH || undefined;

--- a/src/webapp/mcp-server.ts
+++ b/src/webapp/mcp-server.ts
@@ -34,6 +34,8 @@ import * as models from './models';
 import { sanitizeMarkdown, sanitizeQID, detectSecrets, safePath } from './server';
 import { withFileLock } from './file-lock';
 import * as schemas from './schemas';
+import { createStorageProvider } from '../../platform/engine/persistence';
+import type { StorageProvider } from '../../platform/engine/persistence';
 
 /* ── Service layer (M20-004) ───────────────────────────────────── */
 import {
@@ -130,6 +132,9 @@ const AUDIT_DIR: string = path.join(BUSINESS_DOCS, 'audit');
 const store = new FileStore();
 const cache = new FileCache();
 const audit = new AuditTrail({ logDir: AUDIT_DIR });
+
+/* ── StorageProvider (M23-005) ──────────────────────────────────── */
+let _storageProvider: StorageProvider | null = null;
 
 /* ── Service layer context ─────────────────────────────────────── */
 const svcCtx: ServiceContext = {
@@ -873,6 +878,12 @@ mcp.resource(
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 if (require.main === module) {
   (async () => {
+    // Initialize StorageProvider (M23-005)
+    try {
+      _storageProvider = await createStorageProvider();
+    } catch {
+      process.stderr.write('Warning: StorageProvider init failed, continuing without it\n');
+    }
     const transport = new StdioServerTransport();
     await mcp.connect(transport);
   })().catch((err: unknown) => {

--- a/src/webapp/routes/metrics-dashboard.ts
+++ b/src/webapp/routes/metrics-dashboard.ts
@@ -371,8 +371,42 @@ function buildHeatmapData(velocity, kpis) {
 /* ── Route factory ─────────────────────────────────────────────── */
 
 export = function createMetricsDashboardRoutes(ctx): Record<string, unknown> {
-  const { _cache, BUSINESS_DOCS } = ctx;
+  const { _cache, BUSINESS_DOCS, getStorageProvider } = ctx;
   const VELOCITY_FILE = path.join(BUSINESS_DOCS, 'retrospectives', 'velocity-log.json');
+
+  function percentile(sorted: number[], p: number): number {
+    if (!sorted.length) return 0;
+    const idx = Math.ceil((p / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, idx)];
+  }
+
+  function buildStorageMetrics() {
+    const sp = typeof getStorageProvider === 'function' ? getStorageProvider() : null;
+    if (!sp) return null;
+    try {
+      const m = sp.metrics();
+      const readSorted = [...m.readLatencies].sort((a, b) => a - b);
+      const writeSorted = [...m.writeLatencies].sort((a, b) => a - b);
+      return {
+        provider: sp.name,
+        operations: { reads: m.reads, writes: m.writes, deletes: m.deletes, errors: m.errors },
+        latency: {
+          read: {
+            p50: percentile(readSorted, 50),
+            p95: percentile(readSorted, 95),
+            samples: readSorted.length,
+          },
+          write: {
+            p50: percentile(writeSorted, 50),
+            p95: percentile(writeSorted, 95),
+            samples: writeSorted.length,
+          },
+        },
+      };
+    } catch {
+      return { provider: sp.name, error: 'metrics_unavailable' };
+    }
+  }
 
   function readVelocity(store) {
     if (!store.exists(VELOCITY_FILE)) return { sprints: [] };
@@ -454,6 +488,7 @@ export = function createMetricsDashboardRoutes(ctx): Record<string, unknown> {
     const filtered = sliceLast(sorted, lastN);
     const burnup = buildBurnup(sorted);
     const m = computeAllMetrics(sorted, kpis);
+    const storageMetrics = buildStorageMetrics();
 
     json(res, 200, {
       velocity: filtered,
@@ -471,6 +506,7 @@ export = function createMetricsDashboardRoutes(ctx): Record<string, unknown> {
       estimationHistogram: m.estimationHistogram,
       riskTrend: m.riskTrend,
       heatmapData: m.heatmapData,
+      ...(storageMetrics ? { storage: storageMetrics } : {}),
       generated_at: new Date().toISOString(),
     });
   }

--- a/src/webapp/routes/misc.ts
+++ b/src/webapp/routes/misc.ts
@@ -48,6 +48,8 @@ export = function createMiscRoutes(ctx): Record<string, unknown> {
     WEBAPP_DIR,
     ANALYTICS_MAX_EVENTS,
     _readCommandQueue,
+    getStorageProvider,
+    STORAGE_PROVIDER: _storageProviderType,
   } = ctx;
 
   const svc = new SessionService(toServiceContext(ctx));
@@ -267,6 +269,21 @@ export = function createMiscRoutes(ctx): Record<string, unknown> {
     } catch {
       store_status = 'degraded';
     }
+    // StorageProvider health (M23-005 / M23-007)
+    let storage_health: Record<string, unknown> | undefined;
+    const sp = typeof getStorageProvider === 'function' ? getStorageProvider() : null;
+    if (sp) {
+      try {
+        const h = await sp.health();
+        storage_health = {
+          status: h.status,
+          provider: h.provider,
+          latencyMs: h.latencyMs,
+        };
+      } catch {
+        storage_health = { status: 'unhealthy', provider: _storageProviderType || 'unknown' };
+      }
+    }
     json(res, 200, {
       status: 'ok',
       version: _version,
@@ -274,6 +291,7 @@ export = function createMiscRoutes(ctx): Record<string, unknown> {
       store_status,
       sse_connections: sseManager.size,
       timestamp: new Date().toISOString(),
+      ...(storage_health ? { storage: storage_health } : {}),
     });
   }
 
@@ -434,11 +452,13 @@ export = function createMiscRoutes(ctx): Record<string, unknown> {
       } catch {
         store_status = 'degraded';
       }
+      const sp = typeof getStorageProvider === 'function' ? getStorageProvider() : null;
       json(res, 200, {
         status: 'ok',
         version: _version,
         uptime: Math.round(process.uptime()),
         store_status,
+        storage_provider: sp ? sp.name : 'none',
       });
     },
     _serveStatic: serveStatic,

--- a/src/webapp/server.ts
+++ b/src/webapp/server.ts
@@ -49,7 +49,11 @@ import {
   SNAPSHOT_SYNC_INTERVAL_MS,
   RATE_LIMIT_WINDOW_MS,
   RATE_LIMIT_MAX,
+  STORAGE_PROVIDER,
+  STORAGE_PATH,
 } from './config';
+import { createStorageProvider } from '../../platform/engine/persistence';
+import type { StorageProvider } from '../../platform/engine/persistence';
 
 const _cache = new FileCache();
 const _audit = new AuditTrail({ logDir: path.join(BUSINESS_DOCS, 'audit') });
@@ -59,6 +63,33 @@ const rateLimiter = createRateLimiter({
 });
 const sseManager = createSSEManager({ heartbeatMs: SSE_HEARTBEAT_MS });
 const store = () => getStore();
+
+/* ── StorageProvider (M23-005) ────────────────────────────────── */
+let _storageProvider: StorageProvider | null = null;
+function getStorageProvider(): StorageProvider | null {
+  return _storageProvider;
+}
+async function initStorageProvider(): Promise<StorageProvider> {
+  const basePath =
+    STORAGE_PROVIDER === 'file'
+      ? STORAGE_PATH || path.join(PROJECT_ROOT, '.agentic', 'storage')
+      : undefined;
+  const dbPath =
+    STORAGE_PROVIDER === 'sqlite'
+      ? STORAGE_PATH || path.join(PROJECT_ROOT, '.agentic', 'data.db')
+      : undefined;
+  _storageProvider = await createStorageProvider({
+    provider: STORAGE_PROVIDER,
+    basePath,
+    dbPath,
+  });
+  structuredLog('info', 'storage_provider_initialized', {
+    provider: STORAGE_PROVIDER,
+    name: _storageProvider.name,
+  });
+  return _storageProvider;
+}
+
 const metricsCollector = createMetricsCollector({
   flushIntervalMs: METRICS_FLUSH_INTERVAL_MS,
   outputPath: METRICS_FILE,
@@ -165,6 +196,9 @@ const ctx: Record<string, unknown> = {
   SSE_HEARTBEAT_MS,
   ANALYTICS_MAX_EVENTS,
   resolveSessionFile: () => resolveSessionFile(getStore(), _cache, SESSION_DIR),
+  /** StorageProvider getter — returns null pre-init, provider post-init (M23-005). */
+  getStorageProvider,
+  STORAGE_PROVIDER,
 };
 
 const questionnaireRoutes = require('./routes/questionnaires')(ctx);
@@ -302,15 +336,31 @@ if (require.main === module) {
     });
     process.exit(1);
   });
-  server.listen(PORT, HOST, () => {
-    structuredLog('info', 'server_started', {
-      host: HOST,
-      port: PORT,
-      url: `http://${HOST}:${PORT}`,
+  // Initialize StorageProvider before accepting requests (M23-005)
+  initStorageProvider()
+    .then(() => {
+      server.listen(PORT, HOST, () => {
+        structuredLog('info', 'server_started', {
+          host: HOST,
+          port: PORT,
+          url: `http://${HOST}:${PORT}`,
+          storageProvider: STORAGE_PROVIDER,
+        });
+        if (HOST !== '127.0.0.1' && HOST !== 'localhost' && !process.env.API_KEY)
+          structuredLog('warn', 'auth_guard_no_api_key', { host: HOST });
+      });
+    })
+    .catch((err: Error) => {
+      structuredLog('error', 'storage_provider_init_failed', { error: err.message });
+      // Fall back to starting without StorageProvider — FileStore still works
+      server.listen(PORT, HOST, () => {
+        structuredLog('warn', 'server_started_without_storage_provider', {
+          host: HOST,
+          port: PORT,
+          url: `http://${HOST}:${PORT}`,
+        });
+      });
     });
-    if (HOST !== '127.0.0.1' && HOST !== 'localhost' && !process.env.API_KEY)
-      structuredLog('warn', 'auth_guard_no_api_key', { host: HOST });
-  });
   const flushTimer = setInterval(() => metricsCollector.flush(), METRICS_FLUSH_INTERVAL_MS);
   flushTimer.unref();
   let _snap: { createSnapshot(): void } | undefined;
@@ -341,6 +391,9 @@ if (require.main === module) {
     clearInterval(flushTimer);
     clearInterval(snapTimer);
     metricsCollector.flush();
+    // Close StorageProvider gracefully (M23-005)
+    const sp = getStorageProvider();
+    if (sp) sp.close().catch(() => {});
     server.close(() => {
       structuredLog('info', 'server_closed');
       process.exit(0);
@@ -380,4 +433,6 @@ export {
   loadMetrics,
   METRICS_FILE,
   _rateLimitMap,
+  getStorageProvider,
+  initStorageProvider,
 };

--- a/tests/unit/metrics-dashboard.test.js
+++ b/tests/unit/metrics-dashboard.test.js
@@ -356,4 +356,97 @@ describe('metrics-dashboard route (FEAT-01)', () => {
     expect(data.burnup).toHaveLength(0);
     expect(data.forecast.avg_velocity).toBe(0);
   });
+
+  /* ── Storage metrics in dashboard (M23-007) ──────────────────── */
+
+  it('includes storage metrics when getStorageProvider is available', async () => {
+    const store = new InMemoryStore(buildFiles());
+    setStore(store);
+    const cache = new FileCache();
+    const fakeProvider = {
+      name: 'file',
+      metrics() {
+        return {
+          reads: 100,
+          writes: 50,
+          deletes: 5,
+          errors: 2,
+          readLatencies: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+          writeLatencies: [5, 10, 15, 20],
+        };
+      },
+    };
+    const r = createMetricsDashboardRoutes({
+      _cache: cache,
+      BUSINESS_DOCS,
+      getStorageProvider: () => fakeProvider,
+    });
+    const h = r['GET /api/metrics/dashboard'];
+    const res = fakeRes();
+    await h(fakeReq(), res);
+    expect(res.status).toBe(200);
+    const data = res.json;
+    expect(data.storage).toBeDefined();
+    expect(data.storage.provider).toBe('file');
+    expect(data.storage.operations).toEqual({ reads: 100, writes: 50, deletes: 5, errors: 2 });
+    expect(data.storage.latency.read.p50).toBeGreaterThan(0);
+    expect(data.storage.latency.read.p95).toBeGreaterThan(0);
+    expect(data.storage.latency.read.samples).toBe(10);
+    expect(data.storage.latency.write.p50).toBeGreaterThan(0);
+    expect(data.storage.latency.write.p95).toBeGreaterThan(0);
+    expect(data.storage.latency.write.samples).toBe(4);
+  });
+
+  it('omits storage key when getStorageProvider is not in ctx', async () => {
+    const store = new InMemoryStore(buildFiles());
+    setStore(store);
+    const cache = new FileCache();
+    const r = createMetricsDashboardRoutes({ _cache: cache, BUSINESS_DOCS });
+    const h = r['GET /api/metrics/dashboard'];
+    const res = fakeRes();
+    await h(fakeReq(), res);
+    expect(res.status).toBe(200);
+    expect(res.json.storage).toBeUndefined();
+  });
+
+  it('omits storage key when getStorageProvider returns null', async () => {
+    const store = new InMemoryStore(buildFiles());
+    setStore(store);
+    const cache = new FileCache();
+    const r = createMetricsDashboardRoutes({
+      _cache: cache,
+      BUSINESS_DOCS,
+      getStorageProvider: () => null,
+    });
+    const h = r['GET /api/metrics/dashboard'];
+    const res = fakeRes();
+    await h(fakeReq(), res);
+    expect(res.status).toBe(200);
+    expect(res.json.storage).toBeUndefined();
+  });
+
+  it('handles metrics() throwing gracefully', async () => {
+    const store = new InMemoryStore(buildFiles());
+    setStore(store);
+    const cache = new FileCache();
+    const fakeProvider = {
+      name: 'broken',
+      metrics() {
+        throw new Error('db locked');
+      },
+    };
+    const r = createMetricsDashboardRoutes({
+      _cache: cache,
+      BUSINESS_DOCS,
+      getStorageProvider: () => fakeProvider,
+    });
+    const h = r['GET /api/metrics/dashboard'];
+    const res = fakeRes();
+    await h(fakeReq(), res);
+    expect(res.status).toBe(200);
+    const data = res.json;
+    expect(data.storage).toBeDefined();
+    expect(data.storage.provider).toBe('broken');
+    expect(data.storage.error).toBe('metrics_unavailable');
+  });
 });

--- a/tests/unit/persistence/migrate-storage.test.js
+++ b/tests/unit/persistence/migrate-storage.test.js
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+/**
+ * Tests for migrate-storage utility (M23-006).
+ * Exercises the migration round-trip: file→sqlite→file.
+ */
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const {
+  FileStorageProvider,
+  SQLiteStorageProvider,
+} = require('../../../platform/engine/persistence');
+
+/** Create a unique temp directory for each test. */
+function tmpDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `m23-migrate-${prefix}-`));
+}
+
+describe('migrate-storage (M23-006)', () => {
+  let fileDir;
+  let sqliteDir;
+  let fileProvider;
+  let sqliteProvider;
+
+  beforeEach(async () => {
+    fileDir = tmpDir('file');
+    sqliteDir = tmpDir('sqlite');
+    fileProvider = new FileStorageProvider({ basePath: fileDir });
+    sqliteProvider = new SQLiteStorageProvider({
+      dbPath: path.join(sqliteDir, 'test.db'),
+    });
+    await fileProvider.initialize();
+    await sqliteProvider.initialize();
+  });
+
+  afterEach(async () => {
+    await fileProvider.close();
+    await sqliteProvider.close();
+    fs.rmSync(fileDir, { recursive: true, force: true });
+    fs.rmSync(sqliteDir, { recursive: true, force: true });
+  });
+
+  async function seedProvider(provider, collections) {
+    for (const [col, docs] of Object.entries(collections)) {
+      for (const doc of docs) {
+        await provider.write(col, doc.id, doc);
+      }
+    }
+  }
+
+  async function migrateAll(source, target, collections) {
+    for (const col of collections) {
+      const docs = await source.list(col);
+      for (const doc of docs) {
+        await target.write(col, doc.id, doc);
+      }
+    }
+  }
+
+  it('migrates file→sqlite with data preserved', async () => {
+    const seed = {
+      sessions: [
+        { id: 's1', name: 'Session 1', status: 'active' },
+        { id: 's2', name: 'Session 2', status: 'complete' },
+      ],
+      decisions: [{ id: 'd1', title: 'Use SQLite', verdict: 'approved' }],
+    };
+    await seedProvider(fileProvider, seed);
+
+    await migrateAll(fileProvider, sqliteProvider, ['sessions', 'decisions']);
+
+    const sessions = await sqliteProvider.list('sessions');
+    expect(sessions).toHaveLength(2);
+    expect(sessions.find((d) => d.id === 's1').name).toBe('Session 1');
+    expect(sessions.find((d) => d.id === 's2').status).toBe('complete');
+
+    const decisions = await sqliteProvider.list('decisions');
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].title).toBe('Use SQLite');
+  });
+
+  it('migrates sqlite→file with data preserved', async () => {
+    const seed = {
+      commands: [
+        { id: 'c1', command: 'CREATE', project: 'test' },
+        { id: 'c2', command: 'AUDIT', project: 'prod' },
+      ],
+    };
+    await seedProvider(sqliteProvider, seed);
+
+    await migrateAll(sqliteProvider, fileProvider, ['commands']);
+
+    const commands = await fileProvider.list('commands');
+    expect(commands).toHaveLength(2);
+    expect(commands.find((d) => d.id === 'c1').command).toBe('CREATE');
+    expect(commands.find((d) => d.id === 'c2').project).toBe('prod');
+  });
+
+  it('round-trips file→sqlite→file without data loss', async () => {
+    const original = {
+      artifacts: [
+        { id: 'a1', type: 'report', content: 'Hello world', nested: { x: 1, y: [2, 3] } },
+        { id: 'a2', type: 'schema', content: 'foo bar' },
+      ],
+    };
+    await seedProvider(fileProvider, original);
+
+    // file → sqlite
+    await migrateAll(fileProvider, sqliteProvider, ['artifacts']);
+
+    // sqlite → new file provider
+    const fileDir2 = tmpDir('file2');
+    const fileProvider2 = new FileStorageProvider({ basePath: fileDir2 });
+    await fileProvider2.initialize();
+
+    await migrateAll(sqliteProvider, fileProvider2, ['artifacts']);
+
+    const result = await fileProvider2.list('artifacts');
+    expect(result).toHaveLength(2);
+    const a1 = result.find((d) => d.id === 'a1');
+    expect(a1.nested).toEqual({ x: 1, y: [2, 3] });
+    expect(a1.content).toBe('Hello world');
+
+    await fileProvider2.close();
+    fs.rmSync(fileDir2, { recursive: true, force: true });
+  });
+
+  it('handles empty collections gracefully', async () => {
+    // Source has an empty collection dir
+    fs.mkdirSync(path.join(fileDir, 'empty-col'), { recursive: true });
+
+    const docs = await fileProvider.list('empty-col');
+    expect(docs).toHaveLength(0);
+
+    // Migrating empty is a no-op
+    await migrateAll(fileProvider, sqliteProvider, ['empty-col']);
+    const result = await sqliteProvider.list('empty-col');
+    expect(result).toHaveLength(0);
+  });
+
+  it('is idempotent — running migration twice produces same result', async () => {
+    const seed = {
+      metrics: [
+        { id: 'm1', value: 42 },
+        { id: 'm2', value: 99 },
+      ],
+    };
+    await seedProvider(fileProvider, seed);
+
+    await migrateAll(fileProvider, sqliteProvider, ['metrics']);
+    await migrateAll(fileProvider, sqliteProvider, ['metrics']); // second run
+
+    const result = await sqliteProvider.list('metrics');
+    expect(result).toHaveLength(2); // Still 2, not 4 (upsert)
+    expect(result.find((d) => d.id === 'm1').value).toBe(42);
+  });
+
+  it('validates document count match', async () => {
+    await seedProvider(fileProvider, {
+      test: [
+        { id: 't1', v: 1 },
+        { id: 't2', v: 2 },
+      ],
+    });
+
+    await migrateAll(fileProvider, sqliteProvider, ['test']);
+
+    const srcDocs = await fileProvider.list('test');
+    const tgtDocs = await sqliteProvider.list('test');
+    expect(tgtDocs).toHaveLength(srcDocs.length);
+
+    for (const src of srcDocs) {
+      const tgt = tgtDocs.find((d) => d.id === src.id);
+      expect(tgt).toBeTruthy();
+      expect(tgt.v).toBe(src.v);
+    }
+  });
+});

--- a/tests/unit/persistence/storage-contract.test.js
+++ b/tests/unit/persistence/storage-contract.test.js
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+// M23-004: StorageProvider contract test suite
+// Parameterized — every provider implementation must pass all tests.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { FileStorageProvider } = require('../../../platform/engine/persistence/file-provider');
+const { SQLiteStorageProvider } = require('../../../platform/engine/persistence/sqlite-provider');
+
+/* ── Helper: create temp directory per test run ───────────────── */
+
+function tmpDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `sp-test-${label}-`));
+}
+
+/* ── Provider factories ──────────────────────────────────────── */
+
+const providers = [
+  {
+    name: 'FileStorageProvider',
+    create() {
+      const dir = tmpDir('file');
+      const provider = new FileStorageProvider({ basePath: dir });
+      return {
+        provider,
+        cleanup() {
+          fs.rmSync(dir, { recursive: true, force: true });
+        },
+      };
+    },
+  },
+  {
+    name: 'SQLiteStorageProvider',
+    create() {
+      const dir = tmpDir('sqlite');
+      const dbPath = path.join(dir, 'test.db');
+      const provider = new SQLiteStorageProvider({ dbPath });
+      return {
+        provider,
+        cleanup() {
+          fs.rmSync(dir, { recursive: true, force: true });
+        },
+      };
+    },
+  },
+];
+
+/* ── Contract tests (run against every provider) ─────────────── */
+
+describe.each(providers)('StorageProvider contract — $name', ({ create }) => {
+  let provider;
+  let cleanup;
+
+  beforeAll(async () => {
+    const ctx = create();
+    provider = ctx.provider;
+    cleanup = ctx.cleanup;
+    await provider.initialize();
+  });
+
+  afterAll(async () => {
+    await provider.close();
+    cleanup();
+  });
+
+  const COL = 'test-items';
+
+  beforeEach(async () => {
+    const docs = await provider.list(COL);
+    for (const doc of docs) {
+      await provider.delete(COL, doc.id);
+    }
+  });
+
+  // ── 1. Provider identity ───────────────────────────────────
+
+  it('has a non-empty name', () => {
+    expect(provider.name).toBeTruthy();
+    expect(typeof provider.name).toBe('string');
+  });
+
+  // ── 2. CRUD: write + read ──────────────────────────────────
+
+  it('writes and reads a document', async () => {
+    const doc = { id: 'doc-1', title: 'Hello', count: 42 };
+    await provider.write(COL, 'doc-1', doc);
+    const result = await provider.read(COL, 'doc-1');
+    expect(result).toEqual(doc);
+  });
+
+  // ── 3. Read missing document returns null ──────────────────
+
+  it('returns null for missing document', async () => {
+    const result = await provider.read(COL, 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  // ── 4. Write overwrites existing document ──────────────────
+
+  it('overwrites existing document', async () => {
+    const v1 = { id: 'doc-1', version: 1 };
+    const v2 = { id: 'doc-1', version: 2 };
+    await provider.write(COL, 'doc-1', v1);
+    await provider.write(COL, 'doc-1', v2);
+    const result = await provider.read(COL, 'doc-1');
+    expect(result).toEqual(v2);
+  });
+
+  // ── 5. Delete removes document ─────────────────────────────
+
+  it('deletes a document', async () => {
+    await provider.write(COL, 'doc-del', { id: 'doc-del', value: 'x' });
+    await provider.delete(COL, 'doc-del');
+    const result = await provider.read(COL, 'doc-del');
+    expect(result).toBeNull();
+  });
+
+  // ── 6. Delete non-existent is no-op ────────────────────────
+
+  it('delete on non-existent document is no-op', async () => {
+    await expect(provider.delete(COL, 'ghost')).resolves.toBeUndefined();
+  });
+
+  // ── 7. List returns all documents ──────────────────────────
+
+  it('lists all documents in a collection', async () => {
+    await provider.write(COL, 'a', { id: 'a', order: 1 });
+    await provider.write(COL, 'b', { id: 'b', order: 2 });
+    await provider.write(COL, 'c', { id: 'c', order: 3 });
+    const docs = await provider.list(COL);
+    expect(docs).toHaveLength(3);
+    const ids = docs.map((d) => d.id).sort();
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+
+  // ── 8. List empty collection ───────────────────────────────
+
+  it('lists empty collection returns empty array', async () => {
+    const docs = await provider.list('empty-collection');
+    expect(docs).toEqual([]);
+  });
+
+  // ── 9. List with where filter ──────────────────────────────
+
+  it('filters documents with where clause', async () => {
+    await provider.write(COL, 'x1', { id: 'x1', status: 'active' });
+    await provider.write(COL, 'x2', { id: 'x2', status: 'archived' });
+    await provider.write(COL, 'x3', { id: 'x3', status: 'active' });
+    const active = await provider.list(COL, { where: { status: 'active' } });
+    expect(active).toHaveLength(2);
+    expect(active.every((d) => d.status === 'active')).toBe(true);
+  });
+
+  // ── 10. List with limit ────────────────────────────────────
+
+  it('respects limit in list', async () => {
+    await provider.write(COL, 'l1', { id: 'l1' });
+    await provider.write(COL, 'l2', { id: 'l2' });
+    await provider.write(COL, 'l3', { id: 'l3' });
+    const docs = await provider.list(COL, { limit: 2 });
+    expect(docs).toHaveLength(2);
+  });
+
+  // ── 11. List with offset ───────────────────────────────────
+
+  it('respects offset in list', async () => {
+    await provider.write(COL, 'o1', { id: 'o1', order: 1 });
+    await provider.write(COL, 'o2', { id: 'o2', order: 2 });
+    await provider.write(COL, 'o3', { id: 'o3', order: 3 });
+    const all = await provider.list(COL);
+    const offset = await provider.list(COL, { offset: 1 });
+    expect(offset).toHaveLength(all.length - 1);
+  });
+
+  // ── 12. List with orderBy ascending ────────────────────────
+
+  it('sorts documents ascending', async () => {
+    await provider.write(COL, 'z', { id: 'z', rank: 3 });
+    await provider.write(COL, 'a', { id: 'a', rank: 1 });
+    await provider.write(COL, 'm', { id: 'm', rank: 2 });
+    const docs = await provider.list(COL, {
+      orderBy: { field: 'rank', direction: 'asc' },
+    });
+    expect(docs.map((d) => d.rank)).toEqual([1, 2, 3]);
+  });
+
+  // ── 13. List with orderBy descending ───────────────────────
+
+  it('sorts documents descending', async () => {
+    await provider.write(COL, 'z', { id: 'z', rank: 3 });
+    await provider.write(COL, 'a', { id: 'a', rank: 1 });
+    await provider.write(COL, 'm', { id: 'm', rank: 2 });
+    const docs = await provider.list(COL, {
+      orderBy: { field: 'rank', direction: 'desc' },
+    });
+    expect(docs.map((d) => d.rank)).toEqual([3, 2, 1]);
+  });
+
+  // ── 14. Query with text search ─────────────────────────────
+
+  it('queries with text search', async () => {
+    await provider.write(COL, 's1', { id: 's1', title: 'Alpha Bravo' });
+    await provider.write(COL, 's2', { id: 's2', title: 'Charlie Delta' });
+    await provider.write(COL, 's3', { id: 's3', title: 'Bravo Echo' });
+    const results = await provider.query(COL, { text: 'bravo' });
+    expect(results).toHaveLength(2);
+    const ids = results.map((d) => d.id).sort();
+    expect(ids).toEqual(['s1', 's3']);
+  });
+
+  // ── 15. Query with text + where filter ─────────────────────
+
+  it('combines text search with where filter', async () => {
+    await provider.write(COL, 'q1', { id: 'q1', title: 'Alpha', status: 'open' });
+    await provider.write(COL, 'q2', { id: 'q2', title: 'Alpha', status: 'closed' });
+    const results = await provider.query(COL, {
+      text: 'Alpha',
+      where: { status: 'open' },
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('q1');
+  });
+
+  // ── 16. Transaction: multiple writes ───────────────────────
+
+  it('executes transaction with multiple writes', async () => {
+    await provider.transaction([
+      { type: 'write', collection: COL, id: 't1', data: { id: 't1', v: 1 } },
+      { type: 'write', collection: COL, id: 't2', data: { id: 't2', v: 2 } },
+      { type: 'write', collection: COL, id: 't3', data: { id: 't3', v: 3 } },
+    ]);
+    const docs = await provider.list(COL);
+    expect(docs).toHaveLength(3);
+  });
+
+  // ── 17. Transaction: mixed write + delete ──────────────────
+
+  it('executes transaction with writes and deletes', async () => {
+    await provider.write(COL, 'td1', { id: 'td1', keep: true });
+    await provider.write(COL, 'td2', { id: 'td2', keep: false });
+    await provider.transaction([
+      { type: 'write', collection: COL, id: 'td3', data: { id: 'td3', keep: true } },
+      { type: 'delete', collection: COL, id: 'td2' },
+    ]);
+    const remaining = await provider.list(COL);
+    const ids = remaining.map((d) => d.id).sort();
+    expect(ids).toEqual(['td1', 'td3']);
+  });
+
+  // ── 18. Concurrent writes to different documents ───────────
+
+  it('handles concurrent writes to different documents', async () => {
+    const writes = Array.from({ length: 10 }, (_, i) =>
+      provider.write(COL, `cw-${i}`, { id: `cw-${i}`, index: i })
+    );
+    await Promise.all(writes);
+    const docs = await provider.list(COL);
+    expect(docs).toHaveLength(10);
+  });
+
+  // ── 19. Write preserves complex nested data ────────────────
+
+  it('preserves complex nested document data', async () => {
+    const complex = {
+      id: 'nested',
+      meta: { tags: ['a', 'b'], deep: { value: 99 } },
+      items: [1, 2, 3],
+      flag: true,
+      nullable: null,
+    };
+    await provider.write(COL, 'nested', complex);
+    const result = await provider.read(COL, 'nested');
+    expect(result).toEqual(complex);
+  });
+
+  // ── 20. Health check returns healthy ───────────────────────
+
+  it('returns healthy status', async () => {
+    const health = await provider.health();
+    expect(health.status).toBe('healthy');
+    expect(health.provider).toBe(provider.name);
+    expect(typeof health.latencyMs).toBe('number');
+  });
+
+  // ── 21. Metrics are tracked ────────────────────────────────
+
+  it('tracks operation metrics', async () => {
+    // Perform some operations
+    await provider.write(COL, 'metric-doc', { id: 'metric-doc' });
+    await provider.read(COL, 'metric-doc');
+    await provider.delete(COL, 'metric-doc');
+
+    const m = provider.metrics();
+    expect(m.reads).toBeGreaterThan(0);
+    expect(m.writes).toBeGreaterThan(0);
+    expect(m.deletes).toBeGreaterThan(0);
+  });
+
+  // ── 22. Multiple collections are isolated ──────────────────
+
+  it('isolates documents between collections', async () => {
+    await provider.write('colA', 'shared-id', { id: 'shared-id', from: 'a' });
+    await provider.write('colB', 'shared-id', { id: 'shared-id', from: 'b' });
+
+    const fromA = await provider.read('colA', 'shared-id');
+    const fromB = await provider.read('colB', 'shared-id');
+    expect(fromA.from).toBe('a');
+    expect(fromB.from).toBe('b');
+
+    // Clean up extra collections
+    await provider.delete('colA', 'shared-id');
+    await provider.delete('colB', 'shared-id');
+  });
+
+  // ── 23. Empty transaction is no-op ─────────────────────────
+
+  it('handles empty transaction gracefully', async () => {
+    await expect(provider.transaction([])).resolves.toBeUndefined();
+  });
+
+  // ── 24. List with combined filter options ──────────────────
+
+  it('combines where + orderBy + limit', async () => {
+    await provider.write(COL, 'cf1', { id: 'cf1', type: 'bug', priority: 3 });
+    await provider.write(COL, 'cf2', { id: 'cf2', type: 'bug', priority: 1 });
+    await provider.write(COL, 'cf3', { id: 'cf3', type: 'feature', priority: 2 });
+    await provider.write(COL, 'cf4', { id: 'cf4', type: 'bug', priority: 2 });
+
+    const bugs = await provider.list(COL, {
+      where: { type: 'bug' },
+      orderBy: { field: 'priority', direction: 'asc' },
+      limit: 2,
+    });
+    expect(bugs).toHaveLength(2);
+    expect(bugs[0].priority).toBe(1);
+    expect(bugs[1].priority).toBe(2);
+  });
+
+  // ── 25. Write then immediate read consistency ──────────────
+
+  it('read-after-write is consistent', async () => {
+    for (let i = 0; i < 5; i++) {
+      const doc = { id: `raw-${i}`, iteration: i };
+      await provider.write(COL, doc.id, doc);
+      const read = await provider.read(COL, doc.id);
+      expect(read).toEqual(doc);
+    }
+  });
+});


### PR DESCRIPTION
## SDLC4 M23: Durable Persistence Layer

Implements all 7 issues in the M23 milestone — a pluggable persistence layer supporting both file and SQLite backends.

### Issues

| Issue | Title | Status |
|-------|-------|--------|
| M23-001 | StorageProvider interface + types | ✅ |
| M23-002 | FileStorageProvider (atomic writes, backups) | ✅ |
| M23-003 | SQLiteStorageProvider (WAL, UPSERT, indexes) | ✅ |
| M23-004 | Contract test suite (50 tests, both providers) | ✅ |
| M23-005 | Server & MCP server integration | ✅ |
| M23-006 | Migration CLI utility + tests | ✅ |
| M23-007 | Health & metrics observability | ✅ |

### New Files
- `platform/engine/persistence/storage-provider.ts` — Interface & types
- `platform/engine/persistence/file-provider.ts` — File-based provider
- `platform/engine/persistence/sqlite-provider.ts` — SQLite provider
- `platform/engine/persistence/factory.ts` — Provider factory
- `platform/engine/persistence/index.ts` — Barrel export
- `scripts/migrate-storage.ts` — CLI migration tool (`npx tsx scripts/migrate-storage.ts --from file --to sqlite`)
- `tests/unit/persistence/storage-contract.test.js` — 50 contract tests
- `tests/unit/persistence/migrate-storage.test.js` — 6 migration tests

### Modified Files
- `src/webapp/config.ts` — `STORAGE_PROVIDER` and `STORAGE_PATH` env config
- `src/webapp/server.ts` — StorageProvider lifecycle (init/shutdown/ctx injection)
- `src/webapp/mcp-server.ts` — StorageProvider integration
- `src/webapp/routes/misc.ts` — `/api/health` storage health, `/health` provider field
- `src/webapp/routes/metrics-dashboard.ts` — Storage metrics (p50/p95 latency, operation counts)
- `tests/unit/metrics-dashboard.test.js` — 4 new storage metrics tests
- `package.json` — `better-sqlite3` dependency

### Test Results
All **2584 tests passing** (0 failures).