### PR TITLE
E-A3: unify tool calling through ToolExecutor (#686 #708 #709 #710 #711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to
 
 ### Added
 
+- M2/E-A3: Unified tool-calling middleware through `ToolExecutor` (starts #686, #708, #709, #710, #711)
+  - Added runtime tool execution middleware in
+    [platform/engine/tool-execution-middleware.ts](platform/engine/tool-execution-middleware.ts)
+    that resolves canonical tool IDs from `platform/schema/tools.json`, enforces
+    role/profile authorization checks, and emits traceable audit events
+  - Wired `ProviderBackedLlmRuntimeAdapter` to execute provider `toolCalls`
+    through `ToolExecutor` only, feed tool results back into model context, and
+    deny unauthorized operations with explicit `TOOL_UNAUTHORIZED` errors
+  - Added tool invocation telemetry fields to adapter response envelopes:
+    `toolTraceId`, `toolInvocationCount`, and `toolAuditEvents`
+  - Added unit coverage for allowed/denied tool operations in
+    [tests/unit/agent-runtime-adapter.test.js](tests/unit/agent-runtime-adapter.test.js)
+
 - M1/E-A1: Dispatcher Runtime Adapter Integration (closes #683, #697, #698, #699, #700)
   - `AgentRuntimeAdapter` interface + `AdapterRegistry` with `NullAdapter`
     (`ci-test`) and `LogOnlyAdapter` (`local-dev`) built-ins in

--- a/platform/engine/agent-runtime-adapter.ts
+++ b/platform/engine/agent-runtime-adapter.ts
@@ -15,12 +15,30 @@
 import path from 'node:path';
 import { existsSync, readFileSync, promises as fs } from 'node:fs';
 import { createDefaultRegistry, type ProviderRegistry } from '../sdlc/adapters/registry.js';
+import { AdapterRegistry as ToolAdapterRegistry } from '../sdlc/adapters/tool-adapter.js';
+import {
+  GitAdapter,
+  CiAdapter,
+  ContainerAdapter,
+  CloudAdapter,
+  SecurityAdapter,
+  TestingAdapter,
+  LlmAdapter,
+} from '../sdlc/adapters/index.js';
 import type {
   LLMMessage,
   LLMProvider,
   TokenUsage,
+  CompletionResult,
 } from '../sdlc/adapters/contracts/llm-provider.js';
 import { loadContractSections, validateDocument } from './gate-validator.js';
+import { ToolExecutor } from './tool-executor.js';
+import {
+  ToolExecutionMiddleware,
+  ToolAuthorizationError,
+  ToolValidationError,
+  type ToolExecutionAuditEvent,
+} from './tool-execution-middleware.js';
 
 // ─── Interface ────────────────────────────────────────────────
 
@@ -52,6 +70,8 @@ interface AgentInvocationContext {
   predecessorOutputs?: Record<string, string>;
   questionnaireInput?: string | null;
   sessionState?: unknown;
+  role?: 'viewer' | 'operator' | 'admin';
+  profile?: string;
 }
 
 export interface AgentPromptEnvelope {
@@ -83,6 +103,9 @@ export interface AgentResponseEnvelope {
   usage: TokenUsage;
   content: string;
   attempts: number;
+  toolTraceId?: string;
+  toolInvocationCount?: number;
+  toolAuditEvents?: ToolExecutionAuditEvent[];
   contractValidation?: {
     status: 'passed';
     contractPaths: string[];
@@ -97,6 +120,7 @@ interface RuntimeAdapterResult {
   outputPath?: string;
   response?: AgentResponseEnvelope;
   usage?: TokenUsage;
+  toolAuditEvents?: ToolExecutionAuditEvent[];
 }
 
 interface ProviderBackedRuntimeAdapterConfig {
@@ -109,6 +133,9 @@ interface ProviderBackedRuntimeAdapterConfig {
   validationMaxRetries?: number;
   outputDir?: string;
   providerRegistry?: Pick<ProviderRegistry, 'getProvider'>;
+  toolExecutor?: Pick<ToolExecutor, 'execute'>;
+  toolAudit?: { logToolExecution(event: ToolExecutionAuditEvent): void };
+  toolCatalogPath?: string;
 }
 
 interface MockRuntimeAdapterConfig {
@@ -117,10 +144,35 @@ interface MockRuntimeAdapterConfig {
 
 const DEFAULT_OUTPUT_DIR = path.resolve(process.cwd(), 'BusinessDocs', 'session', 'agent-runs');
 const DEFAULT_PROVIDER_REGISTRY = createDefaultRegistry();
+const TOOL_EXECUTION_CACHE_STORE = {
+  _files: {} as Record<string, string>,
+  exists(filePath: string) {
+    return Object.prototype.hasOwnProperty.call(this._files, filePath);
+  },
+  readFile(filePath: string) {
+    return this._files[filePath] || '';
+  },
+  writeFile(filePath: string, data: string) {
+    this._files[filePath] = data;
+  },
+  mkdirp(_dirPath: string) {},
+};
 const FILE_GATE_STORE = {
   exists: existsSync,
   readFile: (filePath: string) => readFileSync(filePath, 'utf8'),
 };
+
+function createDefaultToolExecutor(): ToolExecutor {
+  const registry = new ToolAdapterRegistry();
+  registry.register(new GitAdapter());
+  registry.register(new CiAdapter());
+  registry.register(new ContainerAdapter());
+  registry.register(new CloudAdapter());
+  registry.register(new SecurityAdapter());
+  registry.register(new TestingAdapter());
+  registry.register(new LlmAdapter());
+  return new ToolExecutor({ registry, store: TOOL_EXECUTION_CACHE_STORE });
+}
 
 interface ContractMarkerRequirement {
   anyOf: string[];
@@ -537,6 +589,9 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
   private readonly _timeout?: number;
   private readonly _validationMaxRetries: number;
   private readonly _providerRegistry: Pick<ProviderRegistry, 'getProvider'>;
+  private readonly _toolExecutor: Pick<ToolExecutor, 'execute'>;
+  private readonly _toolAudit?: { logToolExecution(event: ToolExecutionAuditEvent): void };
+  private readonly _toolCatalogPath?: string;
 
   constructor(config: ProviderBackedRuntimeAdapterConfig) {
     super(config.outputDir);
@@ -548,6 +603,115 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
     this._timeout = config.timeout;
     this._validationMaxRetries = config.validationMaxRetries ?? 1;
     this._providerRegistry = config.providerRegistry || DEFAULT_PROVIDER_REGISTRY;
+    this._toolExecutor = config.toolExecutor || createDefaultToolExecutor();
+    this._toolAudit = config.toolAudit;
+    this._toolCatalogPath = config.toolCatalogPath;
+  }
+
+  private _createToolMiddleware(audit?: {
+    logToolExecution(event: ToolExecutionAuditEvent): void;
+  }): ToolExecutionMiddleware {
+    return new ToolExecutionMiddleware({
+      toolExecutor: this._toolExecutor,
+      audit,
+      catalogPath: this._toolCatalogPath,
+    });
+  }
+
+  private async _completeWithToolExecution(options: {
+    provider: LLMProvider;
+    messages: LLMMessage[];
+    model?: string;
+    maxTokens: number;
+    temperature: number;
+    policy: { role?: 'viewer' | 'operator' | 'admin'; profile?: string; traceId: string };
+    maxToolRounds?: number;
+  }): Promise<{ completion: CompletionResult; toolAuditEvents: ToolExecutionAuditEvent[] }> {
+    const {
+      provider,
+      messages,
+      model,
+      maxTokens,
+      temperature,
+      policy,
+      maxToolRounds = 4,
+    } = options;
+
+    const toolAuditEvents: ToolExecutionAuditEvent[] = [];
+    const middleware = this._createToolMiddleware({
+      logToolExecution: (event: ToolExecutionAuditEvent) => {
+        toolAuditEvents.push(event);
+        this._toolAudit?.logToolExecution(event);
+      },
+    });
+
+    let round = 0;
+    let completion = await provider.complete({
+      model,
+      maxTokens,
+      temperature,
+      messages,
+      tools: middleware.listToolDefinitions(),
+    });
+
+    while (completion.toolCalls?.length) {
+      round += 1;
+      if (round > maxToolRounds) {
+        throw new Error(`TOOL_ROUND_LIMIT_EXCEEDED: maxToolRounds=${maxToolRounds}`);
+      }
+
+      const toolResults: Array<Record<string, unknown>> = [];
+      for (const toolCall of completion.toolCalls) {
+        try {
+          const execution = await middleware.execute(
+            {
+              id: toolCall.id,
+              name: toolCall.name,
+              arguments: toolCall.arguments,
+            },
+            {
+              role: policy.role,
+              profile: policy.profile,
+              traceId: policy.traceId,
+            }
+          );
+          toolResults.push({
+            id: toolCall.id,
+            name: toolCall.name,
+            success: execution.success,
+            adapter: execution.adapter,
+            operation: execution.operation,
+            data: execution.data,
+            error: execution.error,
+            fromCache: execution.fromCache,
+          });
+        } catch (err) {
+          if (err instanceof ToolAuthorizationError || err instanceof ToolValidationError) {
+            throw new Error(`${err.code}: ${err.message}`);
+          }
+          throw err;
+        }
+      }
+
+      messages.push({
+        role: 'assistant',
+        content: `Tool calls executed for trace ${policy.traceId}.`,
+      });
+      messages.push({
+        role: 'user',
+        content: `Tool execution results (JSON):\n${JSON.stringify(toolResults, null, 2)}`,
+      });
+
+      completion = await provider.complete({
+        model,
+        maxTokens,
+        temperature,
+        messages,
+        tools: middleware.listToolDefinitions(),
+      });
+    }
+
+    return { completion, toolAuditEvents };
   }
 
   async invoke(
@@ -563,6 +727,7 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
 
     const requestedAt = new Date().toISOString();
     const requestId = createRequestId(agent.id);
+    const toolTraceId = requestId;
     const predecessorOutputs = Object.entries(runtimeContext.predecessorOutputs || {}).map(
       ([source, content]) => ({ source, excerpt: truncate(content, 2500) })
     );
@@ -619,17 +784,29 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
     ];
 
     let result;
+    let toolAuditEvents: ToolExecutionAuditEvent[] = [];
     let validation: ContractValidationResult = { valid: true, findings: [] };
     let attempts = 0;
 
     while (attempts <= this._validationMaxRetries) {
       attempts += 1;
-      result = await provider.complete({
+      const completionResult = await this._completeWithToolExecution({
+        provider,
+        messages,
         model: this._model,
         maxTokens: this._maxTokens,
         temperature: this._temperature,
-        messages,
+        policy: {
+          role: runtimeContext.role,
+          profile:
+            runtimeContext.profile ||
+            (runtimeContext.sessionState as { profile?: string } | undefined)?.profile,
+          traceId: toolTraceId,
+        },
       });
+
+      result = completionResult.completion;
+      toolAuditEvents = completionResult.toolAuditEvents;
 
       validation = validateContractOutput(result.content, contractBinding, runtimeContext);
       if (validation.valid) {
@@ -669,6 +846,9 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
       usage: result.usage,
       content: result.content,
       attempts,
+      toolTraceId,
+      toolInvocationCount: toolAuditEvents.length,
+      toolAuditEvents,
       contractValidation:
         contractBinding.contractPaths.length > 0
           ? {
@@ -685,7 +865,7 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
     };
 
     const outputPath = await this._writeArtifact(agent, response);
-    return { outputPath, response, usage: result.usage };
+    return { outputPath, response, usage: result.usage, toolAuditEvents };
   }
 }
 

--- a/platform/engine/tool-execution-middleware.ts
+++ b/platform/engine/tool-execution-middleware.ts
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Robert Agterhuis. MIT License.
+
+import { createHash, randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { ToolExecutionResult, ToolRequest } from './tool-executor.js';
+
+export type ToolExecutionRole = 'viewer' | 'operator' | 'admin';
+
+export interface ToolExecutionPolicy {
+  role?: ToolExecutionRole;
+  profile?: string;
+  traceId?: string;
+  actor?: string;
+}
+
+export interface LlmToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolExecutionAuditEvent {
+  timestamp: string;
+  traceId: string;
+  toolCallId: string;
+  toolId: string;
+  role: ToolExecutionRole;
+  profile: string;
+  adapter?: string;
+  operation?: string;
+  paramsHash: string;
+  resultHash?: string;
+  success: boolean;
+  errorCode?: string;
+  error?: string;
+  fromCache?: boolean;
+  durationMs?: number;
+}
+
+export interface ToolExecutionAuditSink {
+  logToolExecution(event: ToolExecutionAuditEvent): void;
+}
+
+interface CanonicalTool {
+  id: string;
+  description?: string;
+  capabilities?: { readOnly?: boolean };
+  sideEffects?: string[];
+  parameters?: Array<{ name?: string; type?: string; required?: boolean; description?: string }>;
+}
+
+interface ToolsCatalog {
+  tools: CanonicalTool[];
+}
+
+export class ToolAuthorizationError extends Error {
+  readonly code = 'TOOL_UNAUTHORIZED';
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolAuthorizationError';
+  }
+}
+
+export class ToolValidationError extends Error {
+  readonly code = 'TOOL_INVALID_REQUEST';
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolValidationError';
+  }
+}
+
+function hashValue(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(value) || '')
+    .digest('hex');
+}
+
+function normalizeRole(role: unknown): ToolExecutionRole {
+  if (role === 'admin' || role === 'operator' || role === 'viewer') {
+    return role;
+  }
+  return 'viewer';
+}
+
+function roleLevel(role: ToolExecutionRole): number {
+  if (role === 'admin') return 2;
+  if (role === 'operator') return 1;
+  return 0;
+}
+
+function normalizeProfile(profile: unknown): string {
+  if (typeof profile !== 'string' || profile.trim() === '') {
+    return 'local-dev';
+  }
+  return profile.trim();
+}
+
+function isProductionProfile(profile: string): boolean {
+  return profile.startsWith('production-');
+}
+
+function deriveRequiredRole(tool: CanonicalTool, profile: string): ToolExecutionRole {
+  const readOnly = !!tool.capabilities?.readOnly;
+  if (readOnly) return 'viewer';
+
+  // Production profiles require stricter privileges for mutating calls.
+  if (isProductionProfile(profile)) {
+    return 'admin';
+  }
+
+  return 'operator';
+}
+
+function toToolDefinition(tool: CanonicalTool): {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+} {
+  const props: Record<string, unknown> = {
+    target: { type: 'string', description: 'Tool adapter name/category, e.g. git or GIT.' },
+    operation: { type: 'string', description: 'Operation name supported by the target adapter.' },
+    params: { type: 'object', description: 'Operation parameters to pass to the adapter.' },
+    timeout: { type: 'number', description: 'Optional timeout override in milliseconds.' },
+    skipCache: {
+      type: 'boolean',
+      description: 'Optional cache bypass for side-effect operations.',
+    },
+    sideEffect: {
+      type: 'boolean',
+      description: 'Optional side-effect override for cache semantics.',
+    },
+  };
+
+  return {
+    name: tool.id,
+    description: tool.description || tool.id,
+    parameters: {
+      type: 'object',
+      properties: props,
+      required: ['target', 'operation'],
+      additionalProperties: true,
+    },
+  };
+}
+
+function readToolsCatalog(catalogPath?: string): ToolsCatalog {
+  const resolved = catalogPath || path.resolve(process.cwd(), 'platform', 'schema', 'tools.json');
+  const raw = readFileSync(resolved, 'utf8');
+  return JSON.parse(raw) as ToolsCatalog;
+}
+
+export class ToolExecutionMiddleware {
+  private readonly _toolExecutor: {
+    execute<T = unknown>(request: ToolRequest): Promise<ToolExecutionResult<T>>;
+  };
+  private readonly _audit?: ToolExecutionAuditSink;
+  private readonly _catalog: ToolsCatalog;
+  private readonly _byId: Map<string, CanonicalTool>;
+
+  constructor(options: {
+    toolExecutor: { execute<T = unknown>(request: ToolRequest): Promise<ToolExecutionResult<T>> };
+    audit?: ToolExecutionAuditSink;
+    catalogPath?: string;
+  }) {
+    this._toolExecutor = options.toolExecutor;
+    this._audit = options.audit;
+    this._catalog = readToolsCatalog(options.catalogPath);
+    this._byId = new Map((this._catalog.tools || []).map((tool) => [tool.id, tool]));
+  }
+
+  listToolDefinitions(): Array<{
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  }> {
+    return (this._catalog.tools || []).map(toToolDefinition);
+  }
+
+  async execute(call: LlmToolCall, policy: ToolExecutionPolicy = {}): Promise<ToolExecutionResult> {
+    const traceId = policy.traceId || randomUUID();
+    const role = normalizeRole(policy.role);
+    const profile = normalizeProfile(policy.profile);
+    const toolId = call.name;
+    const paramsHash = hashValue(call.arguments || {});
+
+    const tool = this._byId.get(toolId);
+    if (!tool) {
+      const event: ToolExecutionAuditEvent = {
+        timestamp: new Date().toISOString(),
+        traceId,
+        toolCallId: call.id,
+        toolId,
+        role,
+        profile,
+        paramsHash,
+        success: false,
+        errorCode: 'TOOL_NOT_FOUND',
+        error: `Unknown canonical tool ID '${toolId}'.`,
+      };
+      this._audit?.logToolExecution(event);
+      throw new ToolValidationError(event.error || 'Unknown tool');
+    }
+
+    const requiredRole = deriveRequiredRole(tool, profile);
+    if (roleLevel(role) < roleLevel(requiredRole)) {
+      const event: ToolExecutionAuditEvent = {
+        timestamp: new Date().toISOString(),
+        traceId,
+        toolCallId: call.id,
+        toolId,
+        role,
+        profile,
+        paramsHash,
+        success: false,
+        errorCode: 'TOOL_UNAUTHORIZED',
+        error: `Role '${role}' is not allowed to execute '${toolId}' in profile '${profile}'. Required role: '${requiredRole}'.`,
+      };
+      this._audit?.logToolExecution(event);
+      throw new ToolAuthorizationError(event.error || 'Unauthorized tool operation');
+    }
+
+    const target = call.arguments?.target;
+    const operation = call.arguments?.operation;
+    const params = (call.arguments?.params || {}) as Record<string, unknown>;
+
+    if (typeof target !== 'string' || typeof operation !== 'string') {
+      throw new ToolValidationError(
+        `Tool call '${toolId}' must include string arguments 'target' and 'operation'.`
+      );
+    }
+
+    const request: ToolRequest = {
+      target,
+      operation,
+      params,
+      timeout:
+        typeof call.arguments?.timeout === 'number'
+          ? (call.arguments.timeout as number)
+          : undefined,
+      skipCache: call.arguments?.skipCache === true,
+      sideEffect: call.arguments?.sideEffect === true ? true : undefined,
+    };
+
+    const result = await this._toolExecutor.execute(request);
+    const auditEvent: ToolExecutionAuditEvent = {
+      timestamp: new Date().toISOString(),
+      traceId,
+      toolCallId: call.id,
+      toolId,
+      role,
+      profile,
+      adapter: result.adapter,
+      operation: result.operation,
+      paramsHash,
+      resultHash: hashValue({ success: result.success, data: result.data, error: result.error }),
+      success: result.success,
+      errorCode: result.success ? undefined : 'TOOL_EXECUTION_FAILED',
+      error: result.error || undefined,
+      fromCache: result.fromCache,
+      durationMs: result.duration_ms,
+    };
+    this._audit?.logToolExecution(auditEvent);
+    return result;
+  }
+}

--- a/tests/integration/tool-executor-runtime.integration.test.js
+++ b/tests/integration/tool-executor-runtime.integration.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+
+const { ProviderBackedLlmRuntimeAdapter } = require('../../platform/engine/agent-runtime-adapter');
+
+const AGENT = { id: '01', name: 'Business Analyst' };
+const PLATFORM = 'copilot';
+
+let tmpRoot;
+
+async function writeContractFixture(name, content) {
+  const contractPath = path.join(tmpRoot, name);
+  await fs.writeFile(contractPath, content, 'utf8');
+  return contractPath;
+}
+
+async function writeSkillFixture(name, contractPath) {
+  const skillPath = path.join(tmpRoot, name);
+  const normalizedContractPath = contractPath.replace(/\\/g, '/');
+  const content = [
+    '# Skill Fixture',
+    '',
+    'Use this output contract:',
+    normalizedContractPath,
+    '',
+    'Return only the deliverable content.',
+  ].join('\n');
+  await fs.writeFile(skillPath, content, 'utf8');
+  return skillPath;
+}
+
+function validDeliverable() {
+  return [
+    '## Metadata',
+    '- Agent: Business Analyst',
+    '',
+    '## Findings',
+    '- Finding: runtime tool path verified',
+    '',
+    '## HANDOFF CHECKLIST',
+    '- [x] Item 1',
+    '- [x] Item 2',
+    '- [x] Item 3',
+    '- [x] Item 4',
+    '- [x] Item 5',
+    '- [x] Item 6',
+    '- [x] Item 7',
+    '- [x] Item 8',
+    '- [x] Item 9',
+  ].join('\n');
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'tool-executor-integration-'));
+});
+
+afterEach(async () => {
+  if (tmpRoot) {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+    tmpRoot = null;
+  }
+});
+
+describe('ProviderBackedLlmRuntimeAdapter tool execution integration', () => {
+  it('allows read-only canonical tools for viewer role and emits audit hashes', async () => {
+    const contractPath = await writeContractFixture(
+      'tool-integration-contract.md',
+      [
+        '# Contract',
+        '',
+        '```markdown',
+        '## Metadata',
+        '## Findings',
+        '## HANDOFF CHECKLIST',
+        '```',
+      ].join('\n')
+    );
+    const skillPath = await writeSkillFixture('tool-integration-skill.md', contractPath);
+
+    const complete = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: '',
+        model: 'gpt-test',
+        usage: { promptTokens: 8, completionTokens: 2, totalTokens: 10 },
+        finishReason: 'tool_calls',
+        toolCalls: [
+          {
+            id: 'tc-read-1',
+            name: 'tool.test.run',
+            arguments: {
+              target: 'testing',
+              operation: 'run-unit',
+              params: { pattern: 'tests/unit/example.test.js' },
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        content: validDeliverable(),
+        model: 'gpt-test',
+        usage: { promptTokens: 14, completionTokens: 10, totalTokens: 24 },
+        finishReason: 'stop',
+      });
+
+    const providerRegistry = {
+      getProvider: vi.fn().mockReturnValue({
+        providerName: 'openai',
+        capabilities: {},
+        complete,
+      }),
+    };
+
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      data: { passed: 1, failed: 0 },
+      error: null,
+      duration_ms: 7,
+      adapter: 'testing',
+      operation: 'run-unit',
+      fromCache: false,
+      timestamp: new Date().toISOString(),
+    });
+
+    const adapter = new ProviderBackedLlmRuntimeAdapter({
+      name: 'llm-openai-tools-readonly',
+      providerName: 'openai',
+      outputDir: tmpRoot,
+      providerRegistry,
+      toolExecutor: { execute },
+      validationMaxRetries: 0,
+    });
+
+    const result = await adapter.invoke(AGENT, PLATFORM, {
+      skillFile: skillPath,
+      predecessorOutputs: {},
+      questionnaireInput: null,
+      role: 'viewer',
+      profile: 'production-distributed',
+      sessionState: { mode: 'AUDIT' },
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'testing', operation: 'run-unit' })
+    );
+
+    expect(result.response.toolInvocationCount).toBe(1);
+    expect(result.response.toolTraceId).toBeTruthy();
+    expect(result.response.toolAuditEvents).toHaveLength(1);
+    expect(result.response.toolAuditEvents[0]).toEqual(
+      expect.objectContaining({
+        toolId: 'tool.test.run',
+        role: 'viewer',
+        profile: 'production-distributed',
+        adapter: 'testing',
+        operation: 'run-unit',
+        success: true,
+      })
+    );
+    expect(result.response.toolAuditEvents[0].traceId).toBe(result.response.toolTraceId);
+    expect(result.response.toolAuditEvents[0].paramsHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.response.toolAuditEvents[0].resultHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('denies mutating canonical tools for non-admin roles in production profiles', async () => {
+    const contractPath = await writeContractFixture(
+      'tool-integration-deny-contract.md',
+      ['# Contract', '', '```markdown', '## Metadata', '## HANDOFF CHECKLIST', '```'].join('\n')
+    );
+    const skillPath = await writeSkillFixture('tool-integration-deny-skill.md', contractPath);
+
+    const complete = vi.fn().mockResolvedValue({
+      content: '',
+      model: 'gpt-test',
+      usage: { promptTokens: 8, completionTokens: 2, totalTokens: 10 },
+      finishReason: 'tool_calls',
+      toolCalls: [
+        {
+          id: 'tc-deny-1',
+          name: 'tool.git.commit',
+          arguments: {
+            target: 'git',
+            operation: 'commit',
+            params: { message: 'test commit' },
+          },
+        },
+      ],
+    });
+
+    const providerRegistry = {
+      getProvider: vi.fn().mockReturnValue({
+        providerName: 'openai',
+        capabilities: {},
+        complete,
+      }),
+    };
+
+    const execute = vi.fn();
+    const adapter = new ProviderBackedLlmRuntimeAdapter({
+      name: 'llm-openai-tools-denied',
+      providerName: 'openai',
+      outputDir: tmpRoot,
+      providerRegistry,
+      toolExecutor: { execute },
+      validationMaxRetries: 0,
+    });
+
+    await expect(
+      adapter.invoke(AGENT, PLATFORM, {
+        skillFile: skillPath,
+        predecessorOutputs: {},
+        questionnaireInput: null,
+        role: 'operator',
+        profile: 'production-distributed',
+        sessionState: { mode: 'AUDIT' },
+      })
+    ).rejects.toThrow(/TOOL_UNAUTHORIZED/);
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/agent-runtime-adapter.test.js
+++ b/tests/unit/agent-runtime-adapter.test.js
@@ -529,4 +529,171 @@ describe('ProviderBackedLlmRuntimeAdapter', () => {
     ).rejects.toThrow(/failed contract validation/);
     expect(complete).toHaveBeenCalledTimes(2);
   });
+
+  it('routes model tool calls through ToolExecutor middleware when authorized', async () => {
+    const contractPath = await writeContractFixture(
+      'tool-call-contract.md',
+      [
+        '# Contract',
+        '',
+        '```markdown',
+        '## Metadata',
+        '## Findings',
+        '## HANDOFF CHECKLIST',
+        '```',
+      ].join('\n')
+    );
+    const skillPath = await writeSkillFixture('tool-call-skill.md', contractPath);
+
+    const complete = vi
+      .fn()
+      .mockResolvedValueOnce({
+        content: '',
+        model: 'gpt-test',
+        usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+        finishReason: 'tool_calls',
+        toolCalls: [
+          {
+            id: 'tc-1',
+            name: 'tool.git.commit',
+            arguments: {
+              target: 'git',
+              operation: 'status',
+              params: {},
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        content: [
+          '## Metadata',
+          '- Agent: Business Analyst',
+          '',
+          '## Findings',
+          '- Finding: tool path executed',
+          '',
+          '## HANDOFF CHECKLIST',
+          '- [x] Item 1',
+          '- [x] Item 2',
+          '- [x] Item 3',
+          '- [x] Item 4',
+          '- [x] Item 5',
+          '- [x] Item 6',
+          '- [x] Item 7',
+          '- [x] Item 8',
+          '- [x] Item 9',
+        ].join('\n'),
+        model: 'gpt-test',
+        usage: { promptTokens: 22, completionTokens: 8, totalTokens: 30 },
+        finishReason: 'stop',
+      });
+
+    const providerRegistry = {
+      getProvider: vi.fn().mockReturnValue({
+        providerName: 'openai',
+        capabilities: {},
+        complete,
+      }),
+    };
+
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      data: { clean: true },
+      error: null,
+      duration_ms: 5,
+      adapter: 'git',
+      operation: 'status',
+      fromCache: false,
+      timestamp: new Date().toISOString(),
+    });
+
+    const adapter = new ProviderBackedLlmRuntimeAdapter({
+      name: 'llm-openai-tools',
+      providerName: 'openai',
+      outputDir: tmpRoot,
+      providerRegistry,
+      toolExecutor: { execute },
+      validationMaxRetries: 0,
+    });
+
+    const result = await adapter.invoke(AGENT, PLATFORM, {
+      skillFile: skillPath,
+      predecessorOutputs: {},
+      questionnaireInput: null,
+      role: 'admin',
+      profile: 'production-distributed',
+      sessionState: { mode: 'AUDIT' },
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'git', operation: 'status' })
+    );
+    expect(result.response.toolInvocationCount).toBe(1);
+    expect(result.response.toolAuditEvents[0]).toEqual(
+      expect.objectContaining({
+        toolId: 'tool.git.commit',
+        adapter: 'git',
+        operation: 'status',
+        success: true,
+      })
+    );
+  });
+
+  it('denies unauthorized tool calls with explicit TOOL_UNAUTHORIZED code', async () => {
+    const contractPath = await writeContractFixture(
+      'tool-deny-contract.md',
+      ['# Contract', '', '```markdown', '## Metadata', '## HANDOFF CHECKLIST', '```'].join('\n')
+    );
+    const skillPath = await writeSkillFixture('tool-deny-skill.md', contractPath);
+
+    const complete = vi.fn().mockResolvedValue({
+      content: '',
+      model: 'gpt-test',
+      usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+      finishReason: 'tool_calls',
+      toolCalls: [
+        {
+          id: 'tc-deny-1',
+          name: 'tool.git.commit',
+          arguments: {
+            target: 'git',
+            operation: 'status',
+            params: {},
+          },
+        },
+      ],
+    });
+
+    const providerRegistry = {
+      getProvider: vi.fn().mockReturnValue({
+        providerName: 'openai',
+        capabilities: {},
+        complete,
+      }),
+    };
+
+    const execute = vi.fn();
+    const adapter = new ProviderBackedLlmRuntimeAdapter({
+      name: 'llm-openai-tools-deny',
+      providerName: 'openai',
+      outputDir: tmpRoot,
+      providerRegistry,
+      toolExecutor: { execute },
+      validationMaxRetries: 0,
+    });
+
+    await expect(
+      adapter.invoke(AGENT, PLATFORM, {
+        skillFile: skillPath,
+        predecessorOutputs: {},
+        questionnaireInput: null,
+        role: 'viewer',
+        profile: 'production-distributed',
+        sessionState: { mode: 'AUDIT' },
+      })
+    ).rejects.toThrow(/TOOL_UNAUTHORIZED/);
+
+    expect(execute).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Integrate ToolExecutor middleware into provider-backed runtime tool-calling flow.
- Enforce canonical tool ID validation and RBAC/capability checks from canonical tool catalog.
- Emit tool execution audit events with trace IDs and payload/result hashes.
- Add denied/allowed tests at unit and integration levels.

## Validation
- Integration: 
pm run test:integration passed (15 files, 282 tests).
- Targeted E-A3 tests: 	ests/unit/agent-runtime-adapter.test.js and 	ests/integration/tool-executor-runtime.integration.test.js passed.
- Build: 
pm run build passed.

## Delivered Files
- platform/engine/agent-runtime-adapter.ts
- platform/engine/tool-execution-middleware.ts
- 	ests/unit/agent-runtime-adapter.test.js
- 	ests/integration/tool-executor-runtime.integration.test.js
- CHANGELOG.md

## Traceability
- Commit: 90d5db8

Closes #686
Closes #708
Closes #709
Closes #710
Closes #711