### PR TITLE
UI Redesign Phase 3: implement UI-010, UI-018, UI-025, UI-026

### DIFF
--- a/src/webapp/ui/src/components/ui/access-guard.tsx
+++ b/src/webapp/ui/src/components/ui/access-guard.tsx
@@ -1,9 +1,7 @@
 import type React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ShieldOff } from 'lucide-react';
-import { EmptyState } from '@/components/ui/empty-state';
-import { Spinner } from '@/components/ui/spinner';
-import { Button } from '@/components/ui/button';
+import { PageShell } from '@/components/ui/page-shell';
 import { useAuthorization, type RoleRequirement } from '@/hooks/use-auth';
 
 interface AccessGuardProps {
@@ -19,39 +17,41 @@ export function AccessGuard({ requiredRole, children }: AccessGuardProps) {
 
   if (loading) {
     return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Checking access..." />
-      </div>
+      <PageShell isLoading loadingLabel="Checking access...">
+        {null}
+      </PageShell>
     );
   }
 
   if (!user) {
     return (
-      <div className="p-6">
-        <EmptyState
-          icon={<ShieldOff className="size-8" />}
-          title="Sign in required"
-          description="You need an authenticated session to access this area."
-          action={{ label: 'Go to login', onClick: () => navigate('/login') }}
-        />
-      </div>
+      <PageShell
+        isNoAccess
+        noAccessState={{
+          icon: <ShieldOff className="size-8" />,
+          title: 'Sign in required',
+          description: 'You need an authenticated session to access this area.',
+          action: { label: 'Go to login', onClick: () => navigate('/login') },
+        }}
+      >
+        {null}
+      </PageShell>
     );
   }
 
   if (!hasRequiredRole(requiredRole)) {
     return (
-      <div className="p-6">
-        <EmptyState
-          icon={<ShieldOff className="size-8" />}
-          title="Access restricted"
-          description="Your role does not grant access to this view."
-        />
-        <div className="mt-4 flex justify-center">
-          <Button variant="outline" onClick={() => navigate('/')}>
-            Return to overview
-          </Button>
-        </div>
-      </div>
+      <PageShell
+        isNoAccess
+        noAccessState={{
+          icon: <ShieldOff className="size-8" />,
+          title: 'Access restricted',
+          description: 'Your role does not grant access to this view.',
+          action: { label: 'Return to overview', onClick: () => navigate('/') },
+        }}
+      >
+        {null}
+      </PageShell>
     );
   }
 

--- a/src/webapp/ui/src/components/ui/operational-card.stories.tsx
+++ b/src/webapp/ui/src/components/ui/operational-card.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { OperationalCard } from './operational-card';
+import { Button } from './button';
+import { Activity, ShieldCheck } from 'lucide-react';
+
+const meta = {
+  title: 'UI/OperationalCard',
+  component: OperationalCard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof OperationalCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PendingApproval: Story = {
+  args: {
+    title: 'Approval for release gate PHASE-3',
+    subtitle: 'Policy pack SOC2 controls require explicit human acknowledgement.',
+    icon: <ShieldCheck className="size-4" />,
+    statusLabel: 'Pending review',
+    statusTone: 'warning',
+    meta: [
+      { id: 'requested-by', label: 'Requested by', value: 'orchestrator-engine' },
+      { id: 'scope', label: 'Scope', value: 'release/2026.03.21', tone: 'info' },
+      { id: 'risk', label: 'Risk', value: 'Medium', tone: 'warning' },
+      { id: 'sla', label: 'SLA', value: '18m remaining', tone: 'critical' },
+    ],
+    actions: (
+      <>
+        <Button size="sm">Approve</Button>
+        <Button size="sm" variant="outline">
+          Reject
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const ActiveRun: Story = {
+  args: {
+    title: 'Session run: payments-scope-change',
+    subtitle: 'Execution is in PHASE-3 with one active retry on technical-agent.',
+    icon: <Activity className="size-4" />,
+    statusLabel: 'Running',
+    statusTone: 'info',
+    meta: [
+      { id: 'phase', label: 'Phase', value: 'PHASE-3', tone: 'info' },
+      { id: 'agent', label: 'Agent', value: 'technical-agent', tone: 'success' },
+      { id: 'progress', label: 'Progress', value: '61%' },
+      { id: 'issues', label: 'Open blockers', value: '0', tone: 'success' },
+    ],
+  },
+};

--- a/src/webapp/ui/src/components/ui/operational-card.tsx
+++ b/src/webapp/ui/src/components/ui/operational-card.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type OperationalCardTone = 'neutral' | 'info' | 'success' | 'warning' | 'critical';
+
+const toneToBadgeVariant: Record<
+  OperationalCardTone,
+  'secondary' | 'info' | 'success' | 'warning' | 'error'
+> = {
+  neutral: 'secondary',
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+  critical: 'error',
+};
+
+export interface OperationalCardMetaItem {
+  id: string;
+  label: string;
+  value: string;
+  tone?: OperationalCardTone;
+}
+
+export interface OperationalCardProps extends React.ComponentProps<'div'> {
+  title: string;
+  subtitle?: string;
+  statusLabel?: string;
+  statusTone?: OperationalCardTone;
+  icon?: React.ReactNode;
+  meta?: OperationalCardMetaItem[];
+  actions?: React.ReactNode;
+}
+
+export function OperationalCard({
+  title,
+  subtitle,
+  statusLabel,
+  statusTone = 'neutral',
+  icon,
+  meta = [],
+  actions,
+  className,
+  ...props
+}: OperationalCardProps) {
+  return (
+    <Card elevation="flat" className={cn('p-4 border border-border/70', className)} {...props}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex items-start gap-3">
+          {icon && <div className="mt-0.5 text-muted-foreground">{icon}</div>}
+          <div className="min-w-0">
+            <p className="text-sm font-semibold truncate">{title}</p>
+            {subtitle && <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+        </div>
+        {statusLabel && (
+          <Badge variant={toneToBadgeVariant[statusTone]} className="shrink-0">
+            {statusLabel}
+          </Badge>
+        )}
+      </div>
+
+      {meta.length > 0 && (
+        <dl className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {meta.map((item) => (
+            <div
+              key={item.id}
+              className="rounded-xl border border-border/60 bg-background/70 px-3 py-2"
+            >
+              <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                {item.label}
+              </dt>
+              <dd className="mt-1 flex items-center gap-2 text-xs font-medium">
+                {item.tone && (
+                  <span
+                    className={cn(
+                      'inline-block size-2 rounded-full',
+                      item.tone === 'success' && 'bg-success',
+                      item.tone === 'warning' && 'bg-warning',
+                      item.tone === 'critical' && 'bg-destructive',
+                      item.tone === 'info' && 'bg-info',
+                      item.tone === 'neutral' && 'bg-muted-foreground/50'
+                    )}
+                    aria-hidden="true"
+                  />
+                )}
+                <span>{item.value}</span>
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {actions && <div className="mt-4 flex flex-wrap items-center gap-2">{actions}</div>}
+    </Card>
+  );
+}

--- a/src/webapp/ui/src/components/ui/page-shell.stories.tsx
+++ b/src/webapp/ui/src/components/ui/page-shell.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PageShell } from './page-shell';
-import { Inbox, FileText } from 'lucide-react';
+import { Inbox, FileText, ShieldOff } from 'lucide-react';
 
 const meta = {
   title: 'UI/PageShell',
@@ -93,5 +93,18 @@ export const ErrorThenRetry: Story = {
     error: new Error('ECONNREFUSED: Connection refused'),
     onRetry: () => alert('Retry triggered — in a real app this calls refetch()'),
     children: <div>Content after successful retry</div>,
+  },
+};
+
+export const NoAccess: Story = {
+  args: {
+    isNoAccess: true,
+    noAccessState: {
+      icon: <ShieldOff className="size-12" />,
+      title: 'Access restricted',
+      description: 'Your current role does not have permission to access this section.',
+      action: { label: 'Request access', onClick: () => alert('Requesting access…') },
+    },
+    children: <div>Hidden content</div>,
   },
 };

--- a/src/webapp/ui/src/components/ui/page-shell.tsx
+++ b/src/webapp/ui/src/components/ui/page-shell.tsx
@@ -27,6 +27,15 @@ interface PageShellProps {
     description?: string;
     action?: { label: string; onClick: () => void };
   };
+  /** Whether access to this view is restricted. */
+  isNoAccess?: boolean;
+  /** No-access state configuration. */
+  noAccessState?: {
+    icon?: React.ReactNode;
+    title: string;
+    description?: string;
+    action?: { label: string; onClick: () => void };
+  };
   children: React.ReactNode;
 }
 
@@ -37,6 +46,8 @@ export function PageShell({
   onRetry,
   isEmpty,
   emptyState,
+  isNoAccess,
+  noAccessState,
   children,
 }: PageShellProps) {
   if (isLoading) {
@@ -78,6 +89,19 @@ export function PageShell({
           title={emptyState.title}
           description={emptyState.description}
           action={emptyState.action}
+        />
+      </div>
+    );
+  }
+
+  if (isNoAccess && noAccessState) {
+    return (
+      <div className="motion-fade-in p-(--space-xl)">
+        <EmptyState
+          icon={noAccessState.icon}
+          title={noAccessState.title}
+          description={noAccessState.description}
+          action={noAccessState.action}
         />
       </div>
     );

--- a/src/webapp/ui/src/components/ui/queue-triage-list.stories.tsx
+++ b/src/webapp/ui/src/components/ui/queue-triage-list.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueueTriageList } from './queue-triage-list';
+import { ShieldCheck, Activity, AlertTriangle } from 'lucide-react';
+
+const meta = {
+  title: 'UI/QueueTriageList',
+  component: QueueTriageList,
+  tags: ['autodocs'],
+} satisfies Meta<typeof QueueTriageList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ApprovalsQueue: Story = {
+  args: {
+    title: 'Approvals queue',
+    description: 'Triage approvals by urgency and governance impact.',
+    items: [
+      {
+        id: 'appr-1',
+        title: 'Release gate approval for sprint-42',
+        subtitle: 'Blocking release transition to PHASE-4 until approved.',
+        statusLabel: 'Pending',
+        priority: 'high',
+        icon: <ShieldCheck className="size-4" />,
+        actionLabel: 'Review',
+        meta: [
+          { id: 'requested-by', label: 'Requested by', value: 'governance-agent' },
+          { id: 'due', label: 'Due', value: '12 min', tone: 'critical' },
+        ],
+      },
+      {
+        id: 'appr-2',
+        title: 'Policy exception approval',
+        subtitle: 'Exception requested for temporary sandbox egress.',
+        statusLabel: 'Needs context',
+        priority: 'medium',
+        icon: <AlertTriangle className="size-4" />,
+        actionLabel: 'Inspect',
+        meta: [
+          { id: 'policy', label: 'Policy', value: 'NET-003' },
+          { id: 'risk', label: 'Risk', value: 'Medium', tone: 'warning' },
+        ],
+      },
+    ],
+  },
+};
+
+export const RunsQueue: Story = {
+  args: {
+    title: 'Runs queue',
+    description: 'Prioritize active and blocked orchestration sessions.',
+    items: [
+      {
+        id: 'run-1',
+        title: 'checkout-service-hotfix',
+        subtitle: 'Current phase: PHASE-2',
+        statusLabel: 'Running',
+        priority: 'low',
+        icon: <Activity className="size-4" />,
+        actionLabel: 'Open run',
+        meta: [
+          { id: 'progress', label: 'Progress', value: '47%', tone: 'info' },
+          { id: 'agent', label: 'Agent', value: 'technical-agent', tone: 'success' },
+        ],
+      },
+    ],
+  },
+};
+
+export const EmptyQueue: Story = {
+  args: {
+    title: 'Triage queue',
+    description: 'Everything is currently healthy.',
+    items: [],
+    emptyTitle: 'Queue clear',
+    emptyDescription: 'No items require action right now.',
+  },
+};

--- a/src/webapp/ui/src/components/ui/queue-triage-list.tsx
+++ b/src/webapp/ui/src/components/ui/queue-triage-list.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import { OperationalCard, type OperationalCardMetaItem } from '@/components/ui/operational-card';
+import { ListTodo } from 'lucide-react';
+
+export interface QueueTriageItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  statusLabel: string;
+  statusTone?: 'neutral' | 'info' | 'success' | 'warning' | 'critical';
+  meta?: OperationalCardMetaItem[];
+  priority?: 'low' | 'medium' | 'high';
+  icon?: React.ReactNode;
+  actionLabel?: string;
+}
+
+interface QueueTriageListProps {
+  title: string;
+  description?: string;
+  items: QueueTriageItem[];
+  emptyTitle?: string;
+  emptyDescription?: string;
+  onItemAction?: (id: string) => void;
+}
+
+function priorityToTone(priority: QueueTriageItem['priority']) {
+  if (priority === 'high') return 'critical';
+  if (priority === 'medium') return 'warning';
+  if (priority === 'low') return 'success';
+  return 'neutral';
+}
+
+export function QueueTriageList({
+  title,
+  description,
+  items,
+  emptyTitle = 'No queued items',
+  emptyDescription = 'This queue is currently empty.',
+  onItemAction,
+}: QueueTriageListProps) {
+  return (
+    <section aria-label={title} className="space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold">{title}</h3>
+        {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+      </div>
+
+      {items.length === 0 ? (
+        <EmptyState
+          icon={<ListTodo className="size-8" />}
+          title={emptyTitle}
+          description={emptyDescription}
+        />
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <OperationalCard
+              key={item.id}
+              title={item.title}
+              subtitle={item.subtitle}
+              statusLabel={item.statusLabel}
+              statusTone={item.statusTone ?? priorityToTone(item.priority)}
+              icon={item.icon}
+              meta={item.meta}
+              actions={
+                item.actionLabel && onItemAction ? (
+                  <Button size="sm" variant="outline" onClick={() => onItemAction(item.id)}>
+                    {item.actionLabel}
+                  </Button>
+                ) : undefined
+              }
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/webapp/ui/src/hooks/index.ts
+++ b/src/webapp/ui/src/hooks/index.ts
@@ -92,6 +92,12 @@ export {
 /* Traceability (M10) */
 export { useTraceability } from './use-traceability';
 
+/* Audit/Evidence aggregation (UI-025) */
+export { useAuditEvidenceAggregation } from './use-audit-evidence';
+
+/* Observability contracts (UI-026) */
+export { useObservabilityContracts } from './use-observability-contracts';
+
 /* Sessions (M15) */
 export { useSessions, useSession, useSessionTimeline } from './use-sessions';
 

--- a/src/webapp/ui/src/hooks/use-audit-evidence.ts
+++ b/src/webapp/ui/src/hooks/use-audit-evidence.ts
@@ -1,0 +1,163 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/lib/api-client';
+import { queryKeys } from '@/lib/query-keys';
+import { sampleAuditEvidenceAggregation } from '@/lib/contract-samples';
+import type {
+  ApprovalsListResponse,
+  ArtifactListResponse,
+  AuditEvidenceAggregationResponse,
+  AuditEvidencePack,
+  AuditTimelineEntry,
+} from '@/lib/api-types';
+
+function toPackStatus(coverageScore: number): AuditEvidencePack['status'] {
+  if (coverageScore >= 80) return 'complete';
+  if (coverageScore >= 40) return 'partial';
+  return 'missing';
+}
+
+function buildAuditAggregation(
+  artifacts: ArtifactListResponse['artifacts'],
+  approvals: ApprovalsListResponse['approvals']
+): AuditEvidenceAggregationResponse {
+  const timelineFromArtifacts: AuditTimelineEntry[] = artifacts.slice(0, 80).map((artifact) => ({
+    id: `artifact-${artifact.id}`,
+    timestamp: artifact.updated_at || artifact.created_at,
+    domain: 'artifacts',
+    event_type: 'artifact_registered',
+    title: `${artifact.artifact_type} artifact registered`,
+    description: `${artifact.id} is tracked in ${artifact.stage} with status ${artifact.status}.`,
+    severity: artifact.status === 'INVALID' ? 'critical' : 'info',
+    entity_id: artifact.id,
+    metadata: {
+      stage: artifact.stage,
+      status: artifact.status,
+      hash: artifact.content_hash,
+    },
+  }));
+
+  const timelineFromApprovals: AuditTimelineEntry[] = approvals.slice(0, 80).map((approval) => ({
+    id: `approval-${approval.id}`,
+    timestamp: approval.requested_at,
+    domain: 'approvals',
+    event_type: 'approval_event',
+    title: `${approval.stage} approval ${approval.status.toLowerCase()}`,
+    description: `Approval ${approval.id} requires ${approval.required_role}.`,
+    severity:
+      approval.status === 'REJECTED'
+        ? 'critical'
+        : approval.status === 'PENDING'
+          ? 'warning'
+          : 'info',
+    entity_id: approval.id,
+    metadata: {
+      entity_id: approval.entity_id,
+      requested_by: approval.requested_by,
+    },
+  }));
+
+  const timeline = [...timelineFromArtifacts, ...timelineFromApprovals].sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  const packMap = new Map<
+    string,
+    {
+      title: string;
+      phase: string;
+      artifact_ids: string[];
+      approval_ids: string[];
+      last_updated: string;
+    }
+  >();
+
+  for (const artifact of artifacts) {
+    const key = artifact.stage || 'UNKNOWN';
+    const existing = packMap.get(key);
+    const nextLastUpdated = existing
+      ? new Date(
+          Math.max(
+            new Date(existing.last_updated).getTime(),
+            new Date(artifact.updated_at).getTime()
+          )
+        ).toISOString()
+      : artifact.updated_at;
+    packMap.set(key, {
+      title: `${key} Evidence Pack`,
+      phase: key,
+      artifact_ids: [...(existing?.artifact_ids ?? []), artifact.id],
+      approval_ids: existing?.approval_ids ?? [],
+      last_updated: nextLastUpdated,
+    });
+  }
+
+  for (const approval of approvals) {
+    const key = approval.stage || 'UNKNOWN';
+    const existing = packMap.get(key) ?? {
+      title: `${key} Evidence Pack`,
+      phase: key,
+      artifact_ids: [],
+      approval_ids: [],
+      last_updated: approval.requested_at,
+    };
+    packMap.set(key, {
+      ...existing,
+      approval_ids: [...existing.approval_ids, approval.id],
+      last_updated: new Date(
+        Math.max(
+          new Date(existing.last_updated).getTime(),
+          new Date(approval.requested_at).getTime()
+        )
+      ).toISOString(),
+    });
+  }
+
+  const packs: AuditEvidencePack[] = [...packMap.entries()].map(([id, pack]) => {
+    const artifactWeight = Math.min(70, pack.artifact_ids.length * 10);
+    const approvalWeight = Math.min(30, pack.approval_ids.length * 10);
+    const coverageScore = Math.min(100, artifactWeight + approvalWeight);
+    return {
+      id: `pack-${id.toLowerCase()}`,
+      title: pack.title,
+      status: toPackStatus(coverageScore),
+      phase: pack.phase,
+      artifact_ids: pack.artifact_ids,
+      trace_entity_ids: [],
+      approval_ids: pack.approval_ids,
+      coverage_score: coverageScore,
+      last_updated: pack.last_updated,
+    };
+  });
+
+  const criticalEvents = timeline.filter((entry) => entry.severity === 'critical').length;
+
+  return {
+    ok: true,
+    generated_at: new Date().toISOString(),
+    timeline,
+    packs,
+    summary: {
+      total_events: timeline.length,
+      critical_events: criticalEvents,
+      open_packs: packs.filter((pack) => pack.status !== 'complete').length,
+    },
+  };
+}
+
+export function useAuditEvidenceAggregation() {
+  return useQuery({
+    queryKey: queryKeys.audit.evidence,
+    queryFn: async () => {
+      try {
+        const [artifactRes, approvalRes] = await Promise.all([
+          apiGet<ArtifactListResponse>('/v1/artifacts'),
+          apiGet<ApprovalsListResponse>('/v1/approvals'),
+        ]);
+        return buildAuditAggregation(artifactRes.artifacts, approvalRes.approvals);
+      } catch {
+        return sampleAuditEvidenceAggregation;
+      }
+    },
+    refetchInterval: 60_000,
+  });
+}

--- a/src/webapp/ui/src/hooks/use-observability-contracts.ts
+++ b/src/webapp/ui/src/hooks/use-observability-contracts.ts
@@ -1,0 +1,106 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/lib/api-client';
+import { queryKeys } from '@/lib/query-keys';
+import { sampleObservabilityTelemetryContract } from '@/lib/contract-samples';
+import type {
+  DriftResponse,
+  ObservabilityAlertEntry,
+  ObservabilityTelemetryContractResponse,
+  ObservabilityTelemetryStream,
+  TimestampedResponse,
+  AnalyticsTrendsData,
+} from '@/lib/api-types';
+
+function toAlertSeverity(severity: string): ObservabilityAlertEntry['severity'] {
+  const normalized = severity.toUpperCase();
+  if (normalized === 'CRITICAL') return 'critical';
+  if (normalized === 'WARNING') return 'warning';
+  return 'info';
+}
+
+function buildContracts(
+  drift: DriftResponse | null,
+  trends: TimestampedResponse<AnalyticsTrendsData> | null
+): ObservabilityTelemetryContractResponse {
+  const alerts: ObservabilityAlertEntry[] =
+    drift?.drifts.map((entry) => ({
+      id: entry.id,
+      source: 'drift-detection',
+      severity: toAlertSeverity(entry.severity),
+      status: 'open',
+      message: `${entry.type}: expected ${entry.expected}, actual ${entry.actual}`,
+      first_seen: new Date().toISOString(),
+      last_seen: new Date().toISOString(),
+      metadata: {
+        sprint: entry.sprint,
+        recommendation: entry.recommendation,
+      },
+    })) ?? [];
+
+  const streams: ObservabilityTelemetryStream[] = [];
+  if (trends?.data?.dora?.lead_time?.length) {
+    const points = trends.data.dora.lead_time.map((point) => ({
+      timestamp: point.timestamp,
+      value: point.value,
+    }));
+    streams.push({
+      id: 'stream-lead-time',
+      name: 'Lead time',
+      kind: 'latency',
+      unit: 'hours',
+      latest: points[points.length - 1]?.value ?? 0,
+      sample_count: points.length,
+      points,
+    });
+  }
+
+  if (trends?.data?.dora?.change_failure_rate?.length) {
+    const points = trends.data.dora.change_failure_rate.map((point) => ({
+      timestamp: point.timestamp,
+      value: point.value,
+    }));
+    streams.push({
+      id: 'stream-change-failure',
+      name: 'Change failure rate',
+      kind: 'errors',
+      unit: '%',
+      latest: points[points.length - 1]?.value ?? 0,
+      sample_count: points.length,
+      points,
+    });
+  }
+
+  const criticalAlerts = alerts.filter((alert) => alert.severity === 'critical').length;
+  return {
+    ok: true,
+    generated_at: new Date().toISOString(),
+    alerts,
+    streams,
+    summary: {
+      open_alerts: alerts.filter((alert) => alert.status === 'open').length,
+      critical_alerts: criticalAlerts,
+      stream_count: streams.length,
+      stale_streams: streams.filter((stream) => stream.sample_count === 0).length,
+    },
+  };
+}
+
+export function useObservabilityContracts() {
+  return useQuery({
+    queryKey: queryKeys.observability.contracts,
+    queryFn: async () => {
+      const [driftRes, trendsRes] = await Promise.allSettled([
+        apiGet<DriftResponse>('/v1/drift'),
+        apiGet<TimestampedResponse<AnalyticsTrendsData>>('/v1/analytics/trends'),
+      ]);
+
+      const drift = driftRes.status === 'fulfilled' ? driftRes.value : null;
+      const trends = trendsRes.status === 'fulfilled' ? trendsRes.value : null;
+      if (!drift && !trends) {
+        return sampleObservabilityTelemetryContract;
+      }
+      return buildContracts(drift, trends);
+    },
+    refetchInterval: 30_000,
+  });
+}

--- a/src/webapp/ui/src/lib/api-types.ts
+++ b/src/webapp/ui/src/lib/api-types.ts
@@ -896,6 +896,101 @@ export interface TraceGap {
 }
 
 /* ──────────────────────────────────────────────
+ * Audit/Evidence Aggregation (UI-025)
+ * ────────────────────────────────────────────── */
+
+export type AuditTimelineDomain =
+  | 'artifacts'
+  | 'traceability'
+  | 'approvals'
+  | 'policies'
+  | 'sessions';
+
+export type AuditEventSeverity = 'info' | 'warning' | 'critical';
+
+export interface AuditTimelineEntry {
+  id: string;
+  timestamp: string;
+  domain: AuditTimelineDomain;
+  event_type: string;
+  title: string;
+  description: string;
+  severity: AuditEventSeverity;
+  entity_id?: string;
+  session_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditEvidencePack {
+  id: string;
+  title: string;
+  status: 'complete' | 'partial' | 'missing';
+  phase: string;
+  artifact_ids: string[];
+  trace_entity_ids: string[];
+  approval_ids: string[];
+  coverage_score: number;
+  last_updated: string;
+}
+
+export interface AuditEvidenceAggregationResponse extends OkResponse {
+  generated_at: string;
+  timeline: AuditTimelineEntry[];
+  packs: AuditEvidencePack[];
+  summary: {
+    total_events: number;
+    critical_events: number;
+    open_packs: number;
+  };
+}
+
+/* ──────────────────────────────────────────────
+ * Observability Telemetry Contracts (UI-026)
+ * ────────────────────────────────────────────── */
+
+export type AlertSeverity = 'critical' | 'warning' | 'info';
+export type AlertStatus = 'open' | 'acknowledged' | 'resolved';
+
+export interface ObservabilityAlertEntry {
+  id: string;
+  source: string;
+  severity: AlertSeverity;
+  status: AlertStatus;
+  message: string;
+  first_seen: string;
+  last_seen: string;
+  related_session_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ObservabilityTelemetryPoint {
+  timestamp: string;
+  value: number;
+}
+
+export interface ObservabilityTelemetryStream {
+  id: string;
+  name: string;
+  kind: 'latency' | 'throughput' | 'errors' | 'agent';
+  unit: string;
+  latest: number;
+  sample_count: number;
+  points: ObservabilityTelemetryPoint[];
+}
+
+export interface ObservabilityTelemetryContractResponse extends OkResponse {
+  generated_at: string;
+  alerts: ObservabilityAlertEntry[];
+  streams: ObservabilityTelemetryStream[];
+  summary: {
+    open_alerts: number;
+    critical_alerts: number;
+    stream_count: number;
+    stale_streams: number;
+  };
+}
+
+/* ──────────────────────────────────────────────
  * Sessions (M15 / Issue #M15-022)
  * ────────────────────────────────────────────── */
 

--- a/src/webapp/ui/src/lib/contract-samples.ts
+++ b/src/webapp/ui/src/lib/contract-samples.ts
@@ -1,0 +1,102 @@
+import type {
+  AuditEvidenceAggregationResponse,
+  ObservabilityTelemetryContractResponse,
+} from '@/lib/api-types';
+
+export const sampleAuditEvidenceAggregation: AuditEvidenceAggregationResponse = {
+  ok: true,
+  generated_at: '2026-03-21T08:30:00.000Z',
+  timeline: [
+    {
+      id: 'audit-evt-1',
+      timestamp: '2026-03-21T08:00:00.000Z',
+      domain: 'artifacts',
+      event_type: 'artifact_registered',
+      title: 'Architecture decision package registered',
+      description: 'A governed architecture artifact was added to the registry.',
+      severity: 'info',
+      entity_id: 'ART-ARCH-001',
+    },
+    {
+      id: 'audit-evt-2',
+      timestamp: '2026-03-21T08:12:00.000Z',
+      domain: 'approvals',
+      event_type: 'approval_pending',
+      title: 'Approval pending for release gate',
+      description: 'Release gate approval is waiting on a human reviewer.',
+      severity: 'warning',
+      entity_id: 'APR-RELEASE-001',
+    },
+  ],
+  packs: [
+    {
+      id: 'pack-phase-3',
+      title: 'Phase 3 Evidence Pack',
+      status: 'partial',
+      phase: 'PHASE-3',
+      artifact_ids: ['ART-ARCH-001', 'ART-TEST-113'],
+      trace_entity_ids: ['REQ-200', 'CODE-388', 'TEST-113'],
+      approval_ids: ['APR-RELEASE-001'],
+      coverage_score: 72,
+      last_updated: '2026-03-21T08:15:00.000Z',
+    },
+  ],
+  summary: {
+    total_events: 2,
+    critical_events: 0,
+    open_packs: 1,
+  },
+};
+
+export const sampleObservabilityTelemetryContract: ObservabilityTelemetryContractResponse = {
+  ok: true,
+  generated_at: '2026-03-21T08:30:00.000Z',
+  alerts: [
+    {
+      id: 'alert-1',
+      source: 'drift-detection',
+      severity: 'warning',
+      status: 'open',
+      message: 'Configuration drift detected in sprint checkpoint.',
+      first_seen: '2026-03-21T07:55:00.000Z',
+      last_seen: '2026-03-21T08:27:00.000Z',
+      related_session_id: 'session-204',
+    },
+  ],
+  streams: [
+    {
+      id: 'stream-latency',
+      name: 'Gateway latency p95',
+      kind: 'latency',
+      unit: 'ms',
+      latest: 238,
+      sample_count: 4,
+      points: [
+        { timestamp: '2026-03-21T08:00:00.000Z', value: 190 },
+        { timestamp: '2026-03-21T08:10:00.000Z', value: 205 },
+        { timestamp: '2026-03-21T08:20:00.000Z', value: 221 },
+        { timestamp: '2026-03-21T08:30:00.000Z', value: 238 },
+      ],
+    },
+    {
+      id: 'stream-error-rate',
+      name: 'Error rate',
+      kind: 'errors',
+      unit: '%',
+      latest: 1.2,
+      sample_count: 4,
+      points: [
+        { timestamp: '2026-03-21T08:00:00.000Z', value: 0.5 },
+        { timestamp: '2026-03-21T08:10:00.000Z', value: 0.7 },
+        { timestamp: '2026-03-21T08:20:00.000Z', value: 0.9 },
+        { timestamp: '2026-03-21T08:30:00.000Z', value: 1.2 },
+      ],
+    },
+  ],
+  summary: {
+    open_alerts: 1,
+    critical_alerts: 0,
+    stream_count: 2,
+    stale_streams: 0,
+  },
+};

--- a/src/webapp/ui/src/lib/query-keys.ts
+++ b/src/webapp/ui/src/lib/query-keys.ts
@@ -93,6 +93,16 @@ export const queryKeys = {
     chains: ['traceability', 'chains'] as const,
   },
 
+  /* Audit/Evidence aggregation (UI-025) */
+  audit: {
+    evidence: ['audit', 'evidence'] as const,
+  },
+
+  /* Observability telemetry contracts (UI-026) */
+  observability: {
+    contracts: ['observability', 'contracts'] as const,
+  },
+
   /* Sessions (M15) */
   sessions: {
     all: ['sessions'] as const,

--- a/src/webapp/ui/src/pages/artifacts/artifact-browser-page.tsx
+++ b/src/webapp/ui/src/pages/artifacts/artifact-browser-page.tsx
@@ -11,12 +11,12 @@ import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/ui/data-table';
 import { MetricCard } from '@/components/ui/metric-card';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Spinner } from '@/components/ui/spinner';
-import { AlertBanner } from '@/components/ui/alert-banner';
+import { PageShell } from '@/components/ui/page-shell';
+import { QueueTriageList, type QueueTriageItem } from '@/components/ui/queue-triage-list';
 import { MissionControlHero } from '@/components/ui/mission-control-hero';
 import { StatusMotif } from '@/components/ui/status-motif';
 import { ControlSignalBadge } from '@/components/ui/control-signal';
-import { useArtifacts } from '@/hooks';
+import { useArtifacts, useAuditEvidenceAggregation } from '@/hooks';
 import type { Artifact } from '@/lib/api-types';
 import type { ColumnDef } from '@tanstack/react-table';
 import { Package, Hash, Layers, Filter, RefreshCw } from 'lucide-react';
@@ -90,8 +90,13 @@ export default function ArtifactBrowserPage() {
   }, [filterPhase, filterType, filterStatus]);
 
   const { data, isLoading, error, refetch } = useArtifacts(filters);
+  const auditAggregation = useAuditEvidenceAggregation();
 
   const artifacts = useMemo(() => data?.artifacts ?? [], [data]);
+  const auditTimeline = useMemo(
+    () => auditAggregation.data?.timeline ?? [],
+    [auditAggregation.data?.timeline]
+  );
 
   // Derive unique values for filter dropdowns
   const phases = useMemo(() => [...new Set(artifacts.map((a) => a.stage))].sort(), [artifacts]);
@@ -107,219 +112,253 @@ export default function ArtifactBrowserPage() {
       { id: 'types', label: 'Types', value: String(types.length) },
       { id: 'phases', label: 'Phases', value: String(phases.length) },
       {
+        id: 'audit-events',
+        label: 'Audit events',
+        value: String(auditTimeline.length),
+        tone: auditTimeline.length > 0 ? 'info' : 'neutral',
+      },
+      {
         id: 'filtered',
         label: 'Filters active',
         value: filterPhase || filterType || filterStatus ? 'Yes' : 'No',
         tone: filterPhase || filterType || filterStatus ? 'warning' : 'neutral',
       },
     ],
-    [artifacts.length, types.length, phases.length, filterPhase, filterType, filterStatus]
+    [
+      artifacts.length,
+      types.length,
+      phases.length,
+      auditTimeline.length,
+      filterPhase,
+      filterType,
+      filterStatus,
+    ]
   );
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Loading artifacts…" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-6">
-        <AlertBanner variant="error">
-          <div className="flex items-center justify-between gap-4 w-full">
-            <span>Failed to load artifacts: {(error as Error).message}</span>
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="size-3 mr-1.5" /> Retry
-            </Button>
-          </div>
-        </AlertBanner>
-      </div>
-    );
-  }
+  const auditQueueItems = useMemo<QueueTriageItem[]>(
+    () =>
+      auditTimeline.slice(0, 5).map((event) => ({
+        id: event.id,
+        title: event.title,
+        subtitle: event.description,
+        statusLabel: event.severity,
+        statusTone:
+          event.severity === 'critical'
+            ? 'critical'
+            : event.severity === 'warning'
+              ? 'warning'
+              : 'info',
+        priority:
+          event.severity === 'critical' ? 'high' : event.severity === 'warning' ? 'medium' : 'low',
+        actionLabel: event.entity_id ? 'Inspect entity' : undefined,
+        meta: [
+          { id: `${event.id}-domain`, label: 'Domain', value: event.domain, tone: 'info' },
+          {
+            id: `${event.id}-time`,
+            label: 'Timestamp',
+            value: new Date(event.timestamp).toLocaleString(),
+          },
+        ],
+      })),
+    [auditTimeline]
+  );
 
   return (
-    <div className="p-6 space-y-6" data-testid="artifact-browser-page">
-      <PageHeader
-        title="Artifact Browser"
-        subtitle="Browse governed delivery artifacts as traceable evidence with status, phase, and hash continuity."
-        chips={[
-          { id: 'artifact-registry', label: 'Artifact Registry', tone: 'info' },
-          { id: 'governed', label: 'Governed' },
-        ]}
-      />
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading artifacts…"
+      error={error as Error | null}
+      onRetry={() => refetch()}
+    >
+      <div className="p-6 space-y-6" data-testid="artifact-browser-page">
+        <PageHeader
+          title="Artifact Browser"
+          subtitle="Browse governed delivery artifacts as traceable evidence with status, phase, and hash continuity."
+          chips={[
+            { id: 'artifact-registry', label: 'Artifact Registry', tone: 'info' },
+            { id: 'governed', label: 'Governed' },
+          ]}
+        />
 
-      <ContextStrip items={contextItems} />
+        <ContextStrip items={contextItems} />
 
-      <MissionControlHero
-        eyebrow="Artifact registry"
-        title="Browse governed delivery artifacts as traceable evidence"
-        description="The artifact registry is where generated outputs become inspectable delivery evidence, with status, phase, and hash continuity across the workflow."
-        badges={
-          <>
-            <ControlSignalBadge signal="governed" />
-            <Badge variant="outline">Artifact registry</Badge>
-            {(filterPhase || filterType || filterStatus) && (
-              <ControlSignalBadge signal="active-agent" />
-            )}
-          </>
-        }
-        metrics={[
-          {
-            label: 'Artifacts',
-            value: String(artifacts.length),
-            detail: 'Registered outputs in scope',
-          },
-          { label: 'Types', value: String(types.length), detail: 'Distinct artifact categories' },
-          {
-            label: 'Phases',
-            value: String(phases.length),
-            detail: 'Phases represented in results',
-          },
-          {
-            label: 'Unique hashes',
-            value: String(new Set(artifacts.map((a) => a.content_hash)).size),
-            detail: 'Content fingerprint count',
-          },
-        ]}
-        motifs={
-          <>
-            <StatusMotif
-              kind="governance"
-              title="Evidence remains governed"
-              description="Status and phase metadata make each artifact usable for audits and delivery reviews, not just as a file list."
-            />
-            <StatusMotif
-              kind="agent"
-              title="Artifacts point back to execution"
-              description="Type, phase, and hash fields keep artifact inspection connected to the execution path that produced them."
-            />
-            <StatusMotif
-              kind="human-loop"
-              title="Filtering supports review"
-              description="Operators can narrow the evidence set quickly when a person needs to inspect specific phases or states."
-            />
-          </>
-        }
-        asideTitle="Registry controls"
-        asideDescription="Refresh the registry, apply phase or type filters, and inspect the table as an operational evidence view rather than a flat asset list."
-        asideContent={
-          <Button variant="outline" size="sm" onClick={() => refetch()}>
-            <RefreshCw className="size-4 mr-1" /> Refresh
-          </Button>
-        }
-      />
-
-      {/* Stats */}
-      <section aria-label="Artifact stats">
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          <MetricCard
-            label="Total Artifacts"
-            value={artifacts.length}
-            icon={<Package className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Types"
-            value={types.length}
-            icon={<Layers className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Phases"
-            value={phases.length}
-            icon={<Filter className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Unique Hashes"
-            value={new Set(artifacts.map((a) => a.content_hash)).size}
-            icon={<Hash className="size-4" />}
-            trend="neutral"
-          />
-        </div>
-      </section>
-
-      {/* Filters */}
-      <Card elevation="flat" className="p-4 bg-card/78">
-        <div className="flex items-center gap-3 flex-wrap">
-          <Filter className="size-4 text-muted-foreground" />
-          <select
-            className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
-            value={filterPhase}
-            onChange={(e) => setFilterPhase(e.target.value)}
-            aria-label="Filter by phase"
-          >
-            <option value="">All Phases</option>
-            {phases.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
-          <select
-            className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
-            value={filterType}
-            onChange={(e) => setFilterType(e.target.value)}
-            aria-label="Filter by type"
-          >
-            <option value="">All Types</option>
-            {types.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-          <select
-            className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
-            value={filterStatus}
-            onChange={(e) => setFilterStatus(e.target.value)}
-            aria-label="Filter by status"
-          >
-            <option value="">All Statuses</option>
-            {statuses.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          {(filterPhase || filterType || filterStatus) && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setFilterPhase('');
-                setFilterType('');
-                setFilterStatus('');
-              }}
-            >
-              Clear
+        <MissionControlHero
+          eyebrow="Artifact registry"
+          title="Browse governed delivery artifacts as traceable evidence"
+          description="The artifact registry is where generated outputs become inspectable delivery evidence, with status, phase, and hash continuity across the workflow."
+          badges={
+            <>
+              <ControlSignalBadge signal="governed" />
+              <Badge variant="outline">Artifact registry</Badge>
+              {(filterPhase || filterType || filterStatus) && (
+                <ControlSignalBadge signal="active-agent" />
+              )}
+            </>
+          }
+          metrics={[
+            {
+              label: 'Artifacts',
+              value: String(artifacts.length),
+              detail: 'Registered outputs in scope',
+            },
+            { label: 'Types', value: String(types.length), detail: 'Distinct artifact categories' },
+            {
+              label: 'Phases',
+              value: String(phases.length),
+              detail: 'Phases represented in results',
+            },
+            {
+              label: 'Unique hashes',
+              value: String(new Set(artifacts.map((a) => a.content_hash)).size),
+              detail: 'Content fingerprint count',
+            },
+          ]}
+          motifs={
+            <>
+              <StatusMotif
+                kind="governance"
+                title="Evidence remains governed"
+                description="Status and phase metadata make each artifact usable for audits and delivery reviews, not just as a file list."
+              />
+              <StatusMotif
+                kind="agent"
+                title="Artifacts point back to execution"
+                description="Type, phase, and hash fields keep artifact inspection connected to the execution path that produced them."
+              />
+              <StatusMotif
+                kind="human-loop"
+                title="Filtering supports review"
+                description="Operators can narrow the evidence set quickly when a person needs to inspect specific phases or states."
+              />
+            </>
+          }
+          asideTitle="Registry controls"
+          asideDescription="Refresh the registry, apply phase or type filters, and inspect the table as an operational evidence view rather than a flat asset list."
+          asideContent={
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              <RefreshCw className="size-4 mr-1" /> Refresh
             </Button>
-          )}
-        </div>
-      </Card>
+          }
+        />
 
-      {/* Artifact table */}
-      <section aria-label="Artifact list">
-        {artifacts.length === 0 ? (
-          <EmptyState
-            icon={<Package className="size-12" />}
-            title="No artifacts registered"
-            description="Artifacts will appear here once the engine registers them."
-          />
-        ) : (
-          <DataTable
-            columns={artifactColumns}
-            data={artifacts}
-            enableSorting
-            enableFiltering
-            filterPlaceholder="Search artifacts…"
-            enablePagination
-            emptyTitle="No matching artifacts"
-          />
-        )}
-      </section>
-    </div>
+        <QueueTriageList
+          title="Audit timeline preview"
+          description="Unified audit/evidence aggregation across artifacts and approvals."
+          items={auditQueueItems}
+          emptyTitle="No audit activity"
+          emptyDescription="Audit timeline entries will appear once evidence and approvals are generated."
+        />
+
+        {/* Stats */}
+        <section aria-label="Artifact stats">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <MetricCard
+              label="Total Artifacts"
+              value={artifacts.length}
+              icon={<Package className="size-4" />}
+              trend="neutral"
+            />
+            <MetricCard
+              label="Types"
+              value={types.length}
+              icon={<Layers className="size-4" />}
+              trend="neutral"
+            />
+            <MetricCard
+              label="Phases"
+              value={phases.length}
+              icon={<Filter className="size-4" />}
+              trend="neutral"
+            />
+            <MetricCard
+              label="Unique Hashes"
+              value={new Set(artifacts.map((a) => a.content_hash)).size}
+              icon={<Hash className="size-4" />}
+              trend="neutral"
+            />
+          </div>
+        </section>
+
+        {/* Filters */}
+        <Card elevation="flat" className="p-4 bg-card/78">
+          <div className="flex items-center gap-3 flex-wrap">
+            <Filter className="size-4 text-muted-foreground" />
+            <select
+              className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
+              value={filterPhase}
+              onChange={(e) => setFilterPhase(e.target.value)}
+              aria-label="Filter by phase"
+            >
+              <option value="">All Phases</option>
+              {phases.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <select
+              className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              aria-label="Filter by type"
+            >
+              <option value="">All Types</option>
+              {types.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+            <select
+              className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
+              value={filterStatus}
+              onChange={(e) => setFilterStatus(e.target.value)}
+              aria-label="Filter by status"
+            >
+              <option value="">All Statuses</option>
+              {statuses.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+            {(filterPhase || filterType || filterStatus) && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setFilterPhase('');
+                  setFilterType('');
+                  setFilterStatus('');
+                }}
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        </Card>
+
+        {/* Artifact table */}
+        <section aria-label="Artifact list">
+          {artifacts.length === 0 ? (
+            <EmptyState
+              icon={<Package className="size-12" />}
+              title="No artifacts registered"
+              description="Artifacts will appear here once the engine registers them."
+            />
+          ) : (
+            <DataTable
+              columns={artifactColumns}
+              data={artifacts}
+              enableSorting
+              enableFiltering
+              filterPlaceholder="Search artifacts…"
+              enablePagination
+              emptyTitle="No matching artifacts"
+            />
+          )}
+        </section>
+      </div>
+    </PageShell>
   );
 }

--- a/src/webapp/ui/src/pages/governance/governance-dashboard-page.tsx
+++ b/src/webapp/ui/src/pages/governance/governance-dashboard-page.tsx
@@ -8,12 +8,14 @@ import { Badge } from '@/components/ui/badge';
 import { MetricCard } from '@/components/ui/metric-card';
 import { DataTable } from '@/components/ui/data-table';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Spinner } from '@/components/ui/spinner';
 import { AlertBanner } from '@/components/ui/alert-banner';
+import { Spinner } from '@/components/ui/spinner';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { MissionControlHero } from '@/components/ui/mission-control-hero';
 import { StatusMotif } from '@/components/ui/status-motif';
 import { ControlSignalBadge } from '@/components/ui/control-signal';
+import { QueueTriageList, type QueueTriageItem } from '@/components/ui/queue-triage-list';
+import { PageShell } from '@/components/ui/page-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
 import { DecisionProvenanceView } from '@/components/cockpit/decision-provenance-view';
@@ -26,7 +28,6 @@ import {
   XCircle,
   Clock,
   AlertTriangle,
-  RefreshCw,
   FileCheck,
   Network,
 } from 'lucide-react';
@@ -81,6 +82,34 @@ export default function GovernanceDashboardPage() {
     [approvals]
   );
 
+  const pendingQueueItems = useMemo<QueueTriageItem[]>(
+    () =>
+      pendingApprovals.map((approval) => ({
+        id: approval.id,
+        title: `${approval.stage} approval`,
+        subtitle: `Entity ${approval.entity_id}`,
+        statusLabel: approval.status,
+        statusTone: 'warning',
+        priority: 'high',
+        icon: <ShieldCheck className="size-4" />,
+        actionLabel: 'Review',
+        meta: [
+          {
+            id: `${approval.id}-role`,
+            label: 'Required role',
+            value: approval.required_role,
+            tone: 'warning',
+          },
+          {
+            id: `${approval.id}-requested`,
+            label: 'Requested',
+            value: new Date(approval.requested_at).toLocaleString(),
+          },
+        ],
+      })),
+    [pendingApprovals]
+  );
+
   const contextItems: ContextStripItem[] = [
     {
       id: 'governance-active-tab',
@@ -122,416 +151,411 @@ export default function GovernanceDashboardPage() {
     rejectMutation,
   });
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Loading governance data…" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-6">
-        <AlertBanner variant="error">
-          <div className="flex items-center justify-between gap-4 w-full">
-            <span>Failed to load governance data: {(error as Error).message}</span>
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="size-3 mr-1.5" /> Retry
-            </Button>
-          </div>
-        </AlertBanner>
-      </div>
-    );
-  }
-
   return (
-    <div className="p-6 space-y-6" data-testid="governance-dashboard-page">
-      <PageHeader
-        title="Governance"
-        subtitle="Review approvals, policy compliance, and decision provenance with explicit human oversight."
-        chips={[
-          {
-            id: 'governance-chip-pending',
-            label: `${counts.pending} pending`,
-            tone: counts.pending > 0 ? 'warning' : 'success',
-          },
-          {
-            id: 'governance-chip-approved',
-            label: `${counts.approved} approved`,
-            tone: 'info',
-          },
-          {
-            id: 'governance-chip-rejected',
-            label: `${counts.rejected} rejected`,
-            tone: counts.rejected > 0 ? 'warning' : 'default',
-          },
-        ]}
-      />
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading governance data…"
+      error={error as Error | null}
+      onRetry={() => refetch()}
+    >
+      <div className="p-6 space-y-6" data-testid="governance-dashboard-page">
+        <PageHeader
+          title="Governance"
+          subtitle="Review approvals, policy compliance, and decision provenance with explicit human oversight."
+          chips={[
+            {
+              id: 'governance-chip-pending',
+              label: `${counts.pending} pending`,
+              tone: counts.pending > 0 ? 'warning' : 'success',
+            },
+            {
+              id: 'governance-chip-approved',
+              label: `${counts.approved} approved`,
+              tone: 'info',
+            },
+            {
+              id: 'governance-chip-rejected',
+              label: `${counts.rejected} rejected`,
+              tone: counts.rejected > 0 ? 'warning' : 'default',
+            },
+          ]}
+        />
 
-      <ContextStrip items={contextItems} />
+        <ContextStrip items={contextItems} />
 
-      <MissionControlHero
-        eyebrow="Governance command layer"
-        title="Keep approvals, policy, and release discipline in one governed surface"
-        description="Governance makes the system trustworthy by ensuring every phase gate, approval request, and policy outcome stays visible while delivery continues."
-        badges={
-          <>
-            <ControlSignalBadge signal="governed" />
-            {counts.pending > 0 && <ControlSignalBadge signal="needs-human-input" />}
-            <Badge variant="outline">Advisory mode</Badge>
-          </>
-        }
-        metrics={[
-          {
-            label: 'Pending',
-            value: String(counts.pending),
-            detail: 'Approvals waiting on a human',
-          },
-          {
-            label: 'Approved',
-            value: String(counts.approved),
-            detail: 'Completed governance reviews',
-          },
-          {
-            label: 'Rejected',
-            value: String(counts.rejected),
-            detail: 'Items blocked by governance',
-          },
-          {
-            label: 'Decision lineage',
-            value: String(provenanceQuery.data?.count ?? 0),
-            detail: 'Machine-readable provenance events',
-          },
-        ]}
-        motifs={
-          <>
-            <StatusMotif
-              kind="governance"
-              title="Approvals stay explicit"
-              description="Pending and historical governance decisions are visible as operational workload, not hidden metadata."
-            />
-            <StatusMotif
-              kind="agent"
-              title="Automation respects oversight"
-              description="Governance sits alongside orchestration so automated progress does not bypass accountability."
-            />
-            <StatusMotif
-              kind="human-loop"
-              title="Human review is first-class"
-              description="Anything requiring acceptance or rejection is surfaced as a clear intervention point."
-            />
-          </>
-        }
-        asideTitle="Review rule"
-        asideDescription="Start with Pending Approvals when something is blocked, then switch to Policy Compliance when you need systemic assurance rather than a single decision."
-        asideContent={
-          <div className="space-y-3">
-            <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                Current mode
+        <MissionControlHero
+          eyebrow="Governance command layer"
+          title="Keep approvals, policy, and release discipline in one governed surface"
+          description="Governance makes the system trustworthy by ensuring every phase gate, approval request, and policy outcome stays visible while delivery continues."
+          badges={
+            <>
+              <ControlSignalBadge signal="governed" />
+              {counts.pending > 0 && <ControlSignalBadge signal="needs-human-input" />}
+              <Badge variant="outline">Advisory mode</Badge>
+            </>
+          }
+          metrics={[
+            {
+              label: 'Pending',
+              value: String(counts.pending),
+              detail: 'Approvals waiting on a human',
+            },
+            {
+              label: 'Approved',
+              value: String(counts.approved),
+              detail: 'Completed governance reviews',
+            },
+            {
+              label: 'Rejected',
+              value: String(counts.rejected),
+              detail: 'Items blocked by governance',
+            },
+            {
+              label: 'Decision lineage',
+              value: String(provenanceQuery.data?.count ?? 0),
+              detail: 'Machine-readable provenance events',
+            },
+          ]}
+          motifs={
+            <>
+              <StatusMotif
+                kind="governance"
+                title="Approvals stay explicit"
+                description="Pending and historical governance decisions are visible as operational workload, not hidden metadata."
+              />
+              <StatusMotif
+                kind="agent"
+                title="Automation respects oversight"
+                description="Governance sits alongside orchestration so automated progress does not bypass accountability."
+              />
+              <StatusMotif
+                kind="human-loop"
+                title="Human review is first-class"
+                description="Anything requiring acceptance or rejection is surfaced as a clear intervention point."
+              />
+            </>
+          }
+          asideTitle="Review rule"
+          asideDescription="Start with Pending Approvals when something is blocked, then switch to Policy Compliance when you need systemic assurance rather than a single decision."
+          asideContent={
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Current mode
+                </div>
+                <div className="mt-2 text-sm font-medium">
+                  {activeTab === 'approvals'
+                    ? 'Approval operations'
+                    : activeTab === 'policies'
+                      ? 'Policy compliance review'
+                      : 'Decision provenance review'}
+                </div>
+                <Text muted className="mt-1 text-xs">
+                  Use approvals for case-by-case intervention and policy compliance for systemic
+                  conformance.
+                </Text>
               </div>
-              <div className="mt-2 text-sm font-medium">
-                {activeTab === 'approvals'
-                  ? 'Approval operations'
-                  : activeTab === 'policies'
-                    ? 'Policy compliance review'
-                    : 'Decision provenance review'}
-              </div>
-              <Text muted className="mt-1 text-xs">
-                Use approvals for case-by-case intervention and policy compliance for systemic
-                conformance.
-              </Text>
             </div>
-          </div>
-        }
-      />
+          }
+        />
 
-      {/* Tab navigation */}
-      <div className="flex gap-2 border-b pb-1" role="tablist" aria-label="Governance sections">
-        {activeTab === 'approvals' ? (
-          <button
-            type="button"
-            role="tab"
-            id={approvalsTabId}
-            aria-controls={approvalsPanelId}
-            aria-selected="true"
-            tabIndex={0}
-            onClick={() => setActiveTab('approvals')}
-            className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
-          >
-            <ShieldCheck className="size-3 mr-1.5" /> Approvals
-          </button>
-        ) : (
-          <button
-            type="button"
-            role="tab"
-            id={approvalsTabId}
-            aria-controls={approvalsPanelId}
-            aria-selected="false"
-            tabIndex={-1}
-            onClick={() => setActiveTab('approvals')}
-            className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
-          >
-            <ShieldCheck className="size-3 mr-1.5" /> Approvals
-          </button>
+        {/* Tab navigation */}
+        <div className="flex gap-2 border-b pb-1" role="tablist" aria-label="Governance sections">
+          {activeTab === 'approvals' ? (
+            <button
+              type="button"
+              role="tab"
+              id={approvalsTabId}
+              aria-controls={approvalsPanelId}
+              aria-selected="true"
+              tabIndex={0}
+              onClick={() => setActiveTab('approvals')}
+              className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+            >
+              <ShieldCheck className="size-3 mr-1.5" /> Approvals
+            </button>
+          ) : (
+            <button
+              type="button"
+              role="tab"
+              id={approvalsTabId}
+              aria-controls={approvalsPanelId}
+              aria-selected="false"
+              tabIndex={-1}
+              onClick={() => setActiveTab('approvals')}
+              className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
+            >
+              <ShieldCheck className="size-3 mr-1.5" /> Approvals
+            </button>
+          )}
+          {activeTab === 'policies' ? (
+            <button
+              type="button"
+              role="tab"
+              id={policiesTabId}
+              aria-controls={policiesPanelId}
+              aria-selected="true"
+              tabIndex={0}
+              onClick={() => setActiveTab('policies')}
+              className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+            >
+              <FileCheck className="size-3 mr-1.5" /> Policy Compliance
+            </button>
+          ) : (
+            <button
+              type="button"
+              role="tab"
+              id={policiesTabId}
+              aria-controls={policiesPanelId}
+              aria-selected="false"
+              tabIndex={-1}
+              onClick={() => setActiveTab('policies')}
+              className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
+            >
+              <FileCheck className="size-3 mr-1.5" /> Policy Compliance
+            </button>
+          )}
+          {activeTab === 'provenance' ? (
+            <button
+              type="button"
+              role="tab"
+              id={provenanceTabId}
+              aria-controls={provenancePanelId}
+              aria-selected="true"
+              tabIndex={0}
+              onClick={() => {
+                setProvenancePage(1);
+                setActiveTab('provenance');
+              }}
+              className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+            >
+              <Network className="size-3 mr-1.5" /> Decision Provenance
+            </button>
+          ) : (
+            <button
+              type="button"
+              role="tab"
+              id={provenanceTabId}
+              aria-controls={provenancePanelId}
+              aria-selected="false"
+              tabIndex={-1}
+              onClick={() => {
+                setProvenancePage(1);
+                setActiveTab('provenance');
+              }}
+              className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
+            >
+              <Network className="size-3 mr-1.5" /> Decision Provenance
+            </button>
+          )}
+        </div>
+
+        {activeTab === 'approvals' && (
+          <div role="tabpanel" id={approvalsPanelId} aria-labelledby={approvalsTabId}>
+            {/* Summary cards */}
+            <section aria-label="Governance summary">
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                <MetricCard
+                  label="Pending"
+                  value={counts.pending}
+                  icon={<Clock className="size-4" />}
+                  trend={counts.pending > 0 ? 'down' : 'neutral'}
+                />
+                <MetricCard
+                  label="Approved"
+                  value={counts.approved}
+                  icon={<CheckCircle className="size-4" />}
+                  trend="up"
+                />
+                <MetricCard
+                  label="Rejected"
+                  value={counts.rejected}
+                  icon={<XCircle className="size-4" />}
+                  trend="neutral"
+                />
+                <MetricCard
+                  label="Total"
+                  value={counts.total}
+                  icon={<ShieldCheck className="size-4" />}
+                  trend="neutral"
+                />
+              </div>
+            </section>
+
+            {/* Pending approvals */}
+            <section aria-label="Pending approvals">
+              <Heading level={2} className="mb-3">
+                <AlertTriangle className="size-4 inline mr-2" />
+                Pending Approvals
+              </Heading>
+              <QueueTriageList
+                title="Approval triage queue"
+                description="Review highest-risk approvals first before processing the full table."
+                items={pendingQueueItems}
+                emptyTitle="No pending approvals"
+                emptyDescription="All governance approvals are currently resolved."
+                onItemAction={(id) => {
+                  setRejectingId(id);
+                  window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+                }}
+              />
+              {pendingApprovals.length === 0 ? (
+                <EmptyState
+                  icon={<CheckCircle className="size-12" />}
+                  title="No pending approvals"
+                  description="All approval requests have been handled."
+                />
+              ) : (
+                <DataTable
+                  columns={pendingColumns}
+                  data={pendingApprovals}
+                  enableSorting
+                  emptyTitle="No pending approvals"
+                />
+              )}
+            </section>
+
+            {/* Approval history */}
+            <section aria-label="Approval history">
+              <Heading level={2} className="mb-3">
+                <Clock className="size-4 inline mr-2" />
+                Approval History
+              </Heading>
+              {historyApprovals.length === 0 ? (
+                <EmptyState
+                  icon={<Clock className="size-12" />}
+                  title="No history yet"
+                  description="Approval history will appear after requests are decided."
+                />
+              ) : (
+                <DataTable
+                  columns={historyColumns}
+                  data={historyApprovals}
+                  enableSorting
+                  enablePagination
+                  emptyTitle="No history"
+                />
+              )}
+            </section>
+          </div>
         )}
-        {activeTab === 'policies' ? (
-          <button
-            type="button"
-            role="tab"
-            id={policiesTabId}
-            aria-controls={policiesPanelId}
-            aria-selected="true"
-            tabIndex={0}
-            onClick={() => setActiveTab('policies')}
-            className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
-          >
-            <FileCheck className="size-3 mr-1.5" /> Policy Compliance
-          </button>
-        ) : (
-          <button
-            type="button"
-            role="tab"
-            id={policiesTabId}
-            aria-controls={policiesPanelId}
-            aria-selected="false"
-            tabIndex={-1}
-            onClick={() => setActiveTab('policies')}
-            className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
-          >
-            <FileCheck className="size-3 mr-1.5" /> Policy Compliance
-          </button>
+
+        {activeTab === 'policies' && (
+          <div role="tabpanel" id={policiesPanelId} aria-labelledby={policiesTabId}>
+            <Suspense fallback={<Spinner label="Loading policy panel…" />}>
+              <PolicyCompliancePanel />
+            </Suspense>
+          </div>
         )}
-        {activeTab === 'provenance' ? (
-          <button
-            type="button"
-            role="tab"
-            id={provenanceTabId}
-            aria-controls={provenancePanelId}
-            aria-selected="true"
-            tabIndex={0}
-            onClick={() => {
-              setProvenancePage(1);
-              setActiveTab('provenance');
-            }}
-            className={cn(buttonVariants({ variant: 'default', size: 'sm' }))}
+
+        {activeTab === 'provenance' && (
+          <section
+            aria-label="Decision provenance"
+            className="space-y-4"
+            role="tabpanel"
+            id={provenancePanelId}
+            aria-labelledby={provenanceTabId}
           >
-            <Network className="size-3 mr-1.5" /> Decision Provenance
-          </button>
-        ) : (
-          <button
-            type="button"
-            role="tab"
-            id={provenanceTabId}
-            aria-controls={provenancePanelId}
-            aria-selected="false"
-            tabIndex={-1}
-            onClick={() => {
-              setProvenancePage(1);
-              setActiveTab('provenance');
-            }}
-            className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }))}
-          >
-            <Network className="size-3 mr-1.5" /> Decision Provenance
-          </button>
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1 min-w-45">
+                <Text
+                  id="governance-provenance-actor-label"
+                  className="text-xs uppercase tracking-wide text-muted-foreground"
+                >
+                  Actor
+                </Text>
+                <select
+                  className="h-9 rounded-md border border-border bg-background px-3 text-sm"
+                  aria-labelledby="governance-provenance-actor-label"
+                  aria-label="Actor"
+                  value={provenanceActorType}
+                  onChange={(event) => {
+                    setProvenancePage(1);
+                    setProvenanceActorType(event.target.value as 'all' | 'human' | 'machine');
+                  }}
+                >
+                  <option value="all">All actors</option>
+                  <option value="human">Human</option>
+                  <option value="machine">Machine</option>
+                </select>
+              </div>
+              <div className="space-y-1 min-w-55">
+                <Text
+                  id="governance-provenance-decision-label"
+                  className="text-xs uppercase tracking-wide text-muted-foreground"
+                >
+                  Decision Type
+                </Text>
+                <select
+                  className="h-9 rounded-md border border-border bg-background px-3 text-sm"
+                  aria-labelledby="governance-provenance-decision-label"
+                  aria-label="Decision Type"
+                  value={provenanceDecisionType}
+                  onChange={(event) => {
+                    setProvenancePage(1);
+                    setProvenanceDecisionType(
+                      event.target.value as
+                        | 'all'
+                        | 'human_override'
+                        | 'approval'
+                        | 'policy_exception'
+                        | 'gate_failure'
+                        | 'error'
+                    );
+                  }}
+                >
+                  <option value="all">All decisions</option>
+                  <option value="human_override">Human override</option>
+                  <option value="approval">Approval</option>
+                  <option value="policy_exception">Policy exception</option>
+                  <option value="gate_failure">Gate failure</option>
+                  <option value="error">Error</option>
+                </select>
+              </div>
+            </div>
+
+            {provenanceQuery.isLoading ? (
+              <Spinner label="Loading decision provenance…" />
+            ) : provenanceQuery.isError ? (
+              <AlertBanner variant="warning">
+                Failed to load provenance feed: {(provenanceQuery.error as Error).message}
+              </AlertBanner>
+            ) : (
+              <>
+                <DecisionProvenanceView items={provenanceQuery.data?.items ?? []} />
+                <div className="flex items-center justify-between">
+                  <Text muted className="text-xs">
+                    Showing {provenanceQuery.data?.count ?? 0} of {provenanceQuery.data?.total ?? 0}{' '}
+                    events
+                  </Text>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setProvenancePage((p) => Math.max(1, p - 1))}
+                      disabled={provenancePage <= 1 || provenanceQuery.isFetching}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setProvenancePage((p) => p + 1)}
+                      disabled={
+                        provenanceQuery.isFetching ||
+                        (provenanceQuery.data?.page_size ?? 20) * provenancePage >=
+                          (provenanceQuery.data?.total ?? 0)
+                      }
+                    >
+                      Next
+                    </Button>
+                  </div>
+                </div>
+              </>
+            )}
+          </section>
         )}
       </div>
-
-      {activeTab === 'approvals' && (
-        <div role="tabpanel" id={approvalsPanelId} aria-labelledby={approvalsTabId}>
-          {/* Summary cards */}
-          <section aria-label="Governance summary">
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              <MetricCard
-                label="Pending"
-                value={counts.pending}
-                icon={<Clock className="size-4" />}
-                trend={counts.pending > 0 ? 'down' : 'neutral'}
-              />
-              <MetricCard
-                label="Approved"
-                value={counts.approved}
-                icon={<CheckCircle className="size-4" />}
-                trend="up"
-              />
-              <MetricCard
-                label="Rejected"
-                value={counts.rejected}
-                icon={<XCircle className="size-4" />}
-                trend="neutral"
-              />
-              <MetricCard
-                label="Total"
-                value={counts.total}
-                icon={<ShieldCheck className="size-4" />}
-                trend="neutral"
-              />
-            </div>
-          </section>
-
-          {/* Pending approvals */}
-          <section aria-label="Pending approvals">
-            <Heading level={2} className="mb-3">
-              <AlertTriangle className="size-4 inline mr-2" />
-              Pending Approvals
-            </Heading>
-            {pendingApprovals.length === 0 ? (
-              <EmptyState
-                icon={<CheckCircle className="size-12" />}
-                title="No pending approvals"
-                description="All approval requests have been handled."
-              />
-            ) : (
-              <DataTable
-                columns={pendingColumns}
-                data={pendingApprovals}
-                enableSorting
-                emptyTitle="No pending approvals"
-              />
-            )}
-          </section>
-
-          {/* Approval history */}
-          <section aria-label="Approval history">
-            <Heading level={2} className="mb-3">
-              <Clock className="size-4 inline mr-2" />
-              Approval History
-            </Heading>
-            {historyApprovals.length === 0 ? (
-              <EmptyState
-                icon={<Clock className="size-12" />}
-                title="No history yet"
-                description="Approval history will appear after requests are decided."
-              />
-            ) : (
-              <DataTable
-                columns={historyColumns}
-                data={historyApprovals}
-                enableSorting
-                enablePagination
-                emptyTitle="No history"
-              />
-            )}
-          </section>
-        </div>
-      )}
-
-      {activeTab === 'policies' && (
-        <div role="tabpanel" id={policiesPanelId} aria-labelledby={policiesTabId}>
-          <Suspense fallback={<Spinner label="Loading policy panel…" />}>
-            <PolicyCompliancePanel />
-          </Suspense>
-        </div>
-      )}
-
-      {activeTab === 'provenance' && (
-        <section
-          aria-label="Decision provenance"
-          className="space-y-4"
-          role="tabpanel"
-          id={provenancePanelId}
-          aria-labelledby={provenanceTabId}
-        >
-          <div className="flex flex-wrap items-end gap-3">
-            <div className="space-y-1 min-w-45">
-              <Text
-                id="governance-provenance-actor-label"
-                className="text-xs uppercase tracking-wide text-muted-foreground"
-              >
-                Actor
-              </Text>
-              <select
-                className="h-9 rounded-md border border-border bg-background px-3 text-sm"
-                aria-labelledby="governance-provenance-actor-label"
-                aria-label="Actor"
-                value={provenanceActorType}
-                onChange={(event) => {
-                  setProvenancePage(1);
-                  setProvenanceActorType(event.target.value as 'all' | 'human' | 'machine');
-                }}
-              >
-                <option value="all">All actors</option>
-                <option value="human">Human</option>
-                <option value="machine">Machine</option>
-              </select>
-            </div>
-            <div className="space-y-1 min-w-55">
-              <Text
-                id="governance-provenance-decision-label"
-                className="text-xs uppercase tracking-wide text-muted-foreground"
-              >
-                Decision Type
-              </Text>
-              <select
-                className="h-9 rounded-md border border-border bg-background px-3 text-sm"
-                aria-labelledby="governance-provenance-decision-label"
-                aria-label="Decision Type"
-                value={provenanceDecisionType}
-                onChange={(event) => {
-                  setProvenancePage(1);
-                  setProvenanceDecisionType(
-                    event.target.value as
-                      | 'all'
-                      | 'human_override'
-                      | 'approval'
-                      | 'policy_exception'
-                      | 'gate_failure'
-                      | 'error'
-                  );
-                }}
-              >
-                <option value="all">All decisions</option>
-                <option value="human_override">Human override</option>
-                <option value="approval">Approval</option>
-                <option value="policy_exception">Policy exception</option>
-                <option value="gate_failure">Gate failure</option>
-                <option value="error">Error</option>
-              </select>
-            </div>
-          </div>
-
-          {provenanceQuery.isLoading ? (
-            <Spinner label="Loading decision provenance…" />
-          ) : provenanceQuery.isError ? (
-            <AlertBanner variant="warning">
-              Failed to load provenance feed: {(provenanceQuery.error as Error).message}
-            </AlertBanner>
-          ) : (
-            <>
-              <DecisionProvenanceView items={provenanceQuery.data?.items ?? []} />
-              <div className="flex items-center justify-between">
-                <Text muted className="text-xs">
-                  Showing {provenanceQuery.data?.count ?? 0} of {provenanceQuery.data?.total ?? 0}{' '}
-                  events
-                </Text>
-                <div className="flex gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => setProvenancePage((p) => Math.max(1, p - 1))}
-                    disabled={provenancePage <= 1 || provenanceQuery.isFetching}
-                  >
-                    Previous
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => setProvenancePage((p) => p + 1)}
-                    disabled={
-                      provenanceQuery.isFetching ||
-                      (provenanceQuery.data?.page_size ?? 20) * provenancePage >=
-                        (provenanceQuery.data?.total ?? 0)
-                    }
-                  >
-                    Next
-                  </Button>
-                </div>
-              </div>
-            </>
-          )}
-        </section>
-      )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/webapp/ui/src/pages/observability/observability-page.tsx
+++ b/src/webapp/ui/src/pages/observability/observability-page.tsx
@@ -7,6 +7,10 @@ import { useState, useMemo, lazy, Suspense } from 'react';
 import { Spinner } from '@/components/ui/spinner';
 import { PageHeader } from '@/components/layout/page-header';
 import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
+import { PageShell } from '@/components/ui/page-shell';
+import { QueueTriageList, type QueueTriageItem } from '@/components/ui/queue-triage-list';
+import { OperationalCard } from '@/components/ui/operational-card';
+import { useObservabilityContracts } from '@/hooks';
 
 const MetricsPage = lazy(() => import('@/pages/metrics/metrics-page'));
 const AnalyticsTrendsPage = lazy(() => import('@/pages/analytics/analytics-trends-page'));
@@ -32,78 +36,162 @@ function TabSpinner() {
 
 export default function ObservabilityPage() {
   const [activeTab, setActiveTab] = useState<Tab>('drift');
+  const { data, isLoading, error, refetch } = useObservabilityContracts();
   const activeTabLabel = tabs.find((tab) => tab.id === activeTab)?.label ?? 'Unknown';
+
+  const alertQueueItems = useMemo<QueueTriageItem[]>(
+    () =>
+      (data?.alerts ?? []).slice(0, 5).map((alert) => ({
+        id: alert.id,
+        title: alert.message,
+        subtitle: `${alert.source} · ${alert.status}`,
+        statusLabel: alert.severity,
+        statusTone:
+          alert.severity === 'critical'
+            ? 'critical'
+            : alert.severity === 'warning'
+              ? 'warning'
+              : 'info',
+        priority:
+          alert.severity === 'critical' ? 'high' : alert.severity === 'warning' ? 'medium' : 'low',
+        meta: [
+          {
+            id: `${alert.id}-first`,
+            label: 'First seen',
+            value: new Date(alert.first_seen).toLocaleString(),
+          },
+          {
+            id: `${alert.id}-last`,
+            label: 'Last seen',
+            value: new Date(alert.last_seen).toLocaleString(),
+          },
+        ],
+      })),
+    [data?.alerts]
+  );
 
   const contextItems = useMemo<ContextStripItem[]>(
     () => [
       { id: 'active-view', label: 'Active view', value: activeTabLabel, tone: 'info' },
       { id: 'available-views', label: 'Views', value: String(tabs.length) },
+      {
+        id: 'open-alerts',
+        label: 'Open alerts',
+        value: String(data?.summary.open_alerts ?? 0),
+        tone: (data?.summary.open_alerts ?? 0) > 0 ? 'warning' : 'success',
+      },
+      {
+        id: 'streams',
+        label: 'Telemetry streams',
+        value: String(data?.summary.stream_count ?? 0),
+        tone: 'info',
+      },
       { id: 'loading-mode', label: 'Load mode', value: 'Lazy modules' },
     ],
-    [activeTabLabel]
+    [activeTabLabel, data?.summary.open_alerts, data?.summary.stream_count]
   );
 
   return (
-    <div className="p-6 space-y-6" data-testid="observability-page">
-      <PageHeader
-        title="Observability"
-        subtitle="Drift detection, velocity trends, agent analytics, and traceability"
-        chips={[
-          { id: 'unified-view', label: 'Unified runtime view', tone: 'info' },
-          { id: 'cross-signals', label: 'Cross-signal telemetry' },
-        ]}
-      />
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading observability contracts…"
+      error={error as Error | null}
+      onRetry={() => refetch()}
+    >
+      <div className="p-6 space-y-6" data-testid="observability-page">
+        <PageHeader
+          title="Observability"
+          subtitle="Drift detection, velocity trends, agent analytics, and traceability"
+          chips={[
+            { id: 'unified-view', label: 'Unified runtime view', tone: 'info' },
+            { id: 'cross-signals', label: 'Cross-signal telemetry' },
+          ]}
+        />
 
-      <ContextStrip items={contextItems} />
+        <ContextStrip items={contextItems} />
 
-      {/* Tab bar */}
-      <div
-        role="tablist"
-        aria-label="Observability tabs"
-        className="flex items-center gap-1 border-b"
-      >
-        {tabs.map((tab) =>
-          activeTab === tab.id ? (
-            <button
-              key={tab.id}
-              role="tab"
-              aria-selected="true"
-              aria-controls={`panel-${tab.id}`}
-              id={`tab-${tab.id}`}
-              className="px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px border-primary text-foreground"
-              onClick={() => setActiveTab(tab.id)}
-            >
-              {tab.label}
-            </button>
-          ) : (
-            <button
-              key={tab.id}
-              role="tab"
-              aria-selected="false"
-              aria-controls={`panel-${tab.id}`}
-              id={`tab-${tab.id}`}
-              className="px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50"
-              onClick={() => setActiveTab(tab.id)}
-            >
-              {tab.label}
-            </button>
-          )
+        <QueueTriageList
+          title="Alert triage queue"
+          description="Alert contract from drift and runtime telemetry sources."
+          items={alertQueueItems}
+          emptyTitle="No alerts"
+          emptyDescription="No current alert signals require intervention."
+        />
+
+        {(data?.streams?.length ?? 0) > 0 && (
+          <section
+            aria-label="Telemetry streams"
+            className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+          >
+            {data?.streams.map((stream) => (
+              <OperationalCard
+                key={stream.id}
+                title={stream.name}
+                subtitle={`${stream.sample_count} samples`}
+                statusLabel={stream.kind}
+                statusTone={stream.kind === 'errors' ? 'warning' : 'info'}
+                meta={[
+                  {
+                    id: `${stream.id}-latest`,
+                    label: 'Latest',
+                    value: `${stream.latest} ${stream.unit}`,
+                  },
+                  { id: `${stream.id}-unit`, label: 'Unit', value: stream.unit },
+                ]}
+              />
+            ))}
+          </section>
         )}
-      </div>
 
-      {/* Tab panels */}
-      <div
-        id={`panel-${activeTab}`}
-        role="tabpanel"
-        aria-labelledby={`tab-${activeTab}`}
-        className="-mx-6 -mt-6"
-      >
-        <Suspense fallback={<TabSpinner />}>
-          {activeTab === 'drift' && <MetricsPage />}
-          {activeTab === 'analytics' && <AnalyticsTrendsPage />}
-          {activeTab === 'traceability' && <TraceabilityExplorerPage />}
-        </Suspense>
+        {/* Tab bar */}
+        <div
+          role="tablist"
+          aria-label="Observability tabs"
+          className="flex items-center gap-1 border-b"
+        >
+          {tabs.map((tab) =>
+            activeTab === tab.id ? (
+              <button
+                key={tab.id}
+                role="tab"
+                aria-selected="true"
+                aria-controls={`panel-${tab.id}`}
+                id={`tab-${tab.id}`}
+                className="px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px border-primary text-foreground"
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            ) : (
+              <button
+                key={tab.id}
+                role="tab"
+                aria-selected="false"
+                aria-controls={`panel-${tab.id}`}
+                id={`tab-${tab.id}`}
+                className="px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50"
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            )
+          )}
+        </div>
+
+        {/* Tab panels */}
+        <div
+          id={`panel-${activeTab}`}
+          role="tabpanel"
+          aria-labelledby={`tab-${activeTab}`}
+          className="-mx-6 -mt-6"
+        >
+          <Suspense fallback={<TabSpinner />}>
+            {activeTab === 'drift' && <MetricsPage />}
+            {activeTab === 'analytics' && <AnalyticsTrendsPage />}
+            {activeTab === 'traceability' && <TraceabilityExplorerPage />}
+          </Suspense>
+        </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/src/webapp/ui/src/pages/overview/overview-page.tsx
+++ b/src/webapp/ui/src/pages/overview/overview-page.tsx
@@ -9,9 +9,8 @@ import { Heading, Text } from '@/components/ui/typography';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Spinner } from '@/components/ui/spinner';
 import { EmptyState } from '@/components/ui/empty-state';
-import { AlertBanner } from '@/components/ui/alert-banner';
+import { PageShell } from '@/components/ui/page-shell';
 import { MissionControlHero } from '@/components/ui/mission-control-hero';
 import { StatusMotif } from '@/components/ui/status-motif';
 import { ControlSignalBadge } from '@/components/ui/control-signal';
@@ -29,7 +28,7 @@ import { ContextStrip, type ContextStripItem } from '@/components/layout/context
 import { useSessions, useSession, useDecisions, useDashboardHealth } from '@/hooks';
 import { useUIStore } from '@/stores/ui-store';
 import type { Session, HealthIndicator, TimelineEvent, AgentDetailEntry } from '@/lib/api-types';
-import { Package, Scale, ArrowRight, Rocket, RefreshCw, Activity, ShieldCheck } from 'lucide-react';
+import { Package, Scale, ArrowRight, Rocket, Activity, ShieldCheck } from 'lucide-react';
 
 /* ── Phase derivation (shared logic with session-detail) ── */
 const PHASE_ORDER = ['PHASE-1', 'PHASE-2', 'PHASE-3', 'PHASE-4', 'PHASE-5'];
@@ -192,330 +191,309 @@ export default function OverviewPage() {
     [activeSession, healthAttentionCount]
   );
 
-  if (sessionsLoading || healthLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Loading overview…" />
-      </div>
-    );
-  }
-
-  if (sessionsError || healthError) {
-    const err = sessionsError || healthError;
-    return (
-      <div className="p-6">
-        <AlertBanner variant="error">
-          <div className="flex items-center justify-between gap-4 w-full">
-            <span>Failed to load overview: {(err as Error).message}</span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                refetchSessions();
-                refetchHealth();
-              }}
-            >
-              <RefreshCw className="size-3 mr-1.5" /> Retry
-            </Button>
-          </div>
-        </AlertBanner>
-      </div>
-    );
-  }
-
   return (
-    <div className="p-6 space-y-6" data-testid="overview-page">
-      <PageHeader
-        title="Overview"
-        subtitle="Track runtime flow, governance checkpoints, and health signals from one operational control surface."
-        chips={[...headerChips]}
-        actions={
-          activeSession ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="motion-transition-base"
-              onClick={() => navigate(`/sessions/${encodeURIComponent(activeSession.id)}`)}
-            >
-              Open Session <ArrowRight className="ml-1 size-3" />
-            </Button>
-          ) : (
-            <Button
-              size="sm"
-              className="motion-transition-base"
-              onClick={() => navigate('/commands')}
-            >
-              Start Command <Rocket className="ml-1 size-3" />
-            </Button>
-          )
-        }
-      />
-
-      <ContextStrip items={contextItems} />
-
-      <MissionControlHero
-        eyebrow="Executive overview"
-        title="See governed delivery, live agent motion, and human checkpoints in one view"
-        description="Overview acts as the operator summary for the whole product: what is active now, what needs judgment next, and what evidence is accumulating behind each cycle."
-        badges={
-          <>
-            <ControlSignalBadge signal="governed" />
-            {activeSession?.current_agent && <ControlSignalBadge signal="active-agent" />}
-            {openDecisions.length > 0 && <ControlSignalBadge signal="needs-human-input" />}
-          </>
-        }
-        metrics={[
-          {
-            label: 'Active session',
-            value: activeSession?.project ?? 'None',
-            detail: 'Current primary workstream',
-          },
-          {
-            label: 'Current phase',
-            value: activeSession?.phase ?? 'Idle',
-            detail: 'Latest visible runtime phase',
-          },
-          {
-            label: 'Open decisions',
-            value: String(openDecisions.length),
-            detail: 'Human choices still pending',
-          },
-          {
-            label: 'Health signals',
-            value: String(healthAttentionCount),
-            detail: 'Non-green health indicators',
-          },
-        ]}
-        motifs={
-          <>
-            <StatusMotif
-              kind="governance"
-              title="Governance remains in the foreground"
-              description="Decision count, health signals, and next steps are visible before users dive into lower-level detail."
-            />
-            <StatusMotif
-              kind="agent"
-              title="Agent activity stays legible"
-              description="The active session, phase flow, and current executor are readable as one operational story."
-            />
-            <StatusMotif
-              kind="human-loop"
-              title="Human checkpoints are prioritized"
-              description="Open decisions and guidance keep the operator focused on interventions that unlock progress."
-            />
-          </>
-        }
-        asideTitle="Operator focus"
-        asideDescription="Start here when you need the fastest possible understanding of current delivery state and the next action that needs a human response."
-        asideContent={
-          <div className="space-y-3">
-            <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <Activity className="size-4 text-info" /> What this page answers
-              </div>
-              <Text muted className="mt-1 text-xs">
-                What is running, what is blocked, and what you should review next.
-              </Text>
-            </div>
-            <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <ShieldCheck className="size-4 text-info" /> Why it matters
-              </div>
-              <Text muted className="mt-1 text-xs">
-                It keeps strategic oversight and runtime evidence together instead of splitting them
-                across disconnected screens.
-              </Text>
-            </div>
-          </div>
-        }
-      />
-
-      {/* Welcome Wizard — first-time users (M15-040) */}
-      {!wizardDismissed && <WelcomeWizard onDismiss={dismissWizard} />}
-
-      {shouldShowDiagnostics && (
-        <OnboardingDiagnosticsWizard
-          sessionId={activeSession?.id ?? null}
-          onDismiss={dismissDiagnostics}
+    <PageShell
+      isLoading={sessionsLoading || healthLoading}
+      loadingLabel="Loading overview…"
+      error={(sessionsError || healthError) as Error | null}
+      onRetry={() => {
+        refetchSessions();
+        refetchHealth();
+      }}
+    >
+      <div className="p-6 space-y-6" data-testid="overview-page">
+        <PageHeader
+          title="Overview"
+          subtitle="Track runtime flow, governance checkpoints, and health signals from one operational control surface."
+          chips={[...headerChips]}
+          actions={
+            activeSession ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="motion-transition-base"
+                onClick={() => navigate(`/sessions/${encodeURIComponent(activeSession.id)}`)}
+              >
+                Open Session <ArrowRight className="ml-1 size-3" />
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                className="motion-transition-base"
+                onClick={() => navigate('/commands')}
+              >
+                Start Command <Rocket className="ml-1 size-3" />
+              </Button>
+            )
+          }
         />
-      )}
 
-      {/* What's Next — contextual guidance (M21-002) */}
-      <WhatsNextGuidance />
+        <ContextStrip items={contextItems} />
 
-      {/* Active Session Hero */}
-      <section aria-label="Active session">
-        <SessionStatus
-          session={sessionSummary}
-          progress={activeSession?.progress ?? 0}
-          activePhase={activeSession?.phase}
-          activeAgent={activeSession?.current_agent ?? undefined}
-          connectionStatus={connectionStatus}
+        <MissionControlHero
+          eyebrow="Executive overview"
+          title="See governed delivery, live agent motion, and human checkpoints in one view"
+          description="Overview acts as the operator summary for the whole product: what is active now, what needs judgment next, and what evidence is accumulating behind each cycle."
+          badges={
+            <>
+              <ControlSignalBadge signal="governed" />
+              {activeSession?.current_agent && <ControlSignalBadge signal="active-agent" />}
+              {openDecisions.length > 0 && <ControlSignalBadge signal="needs-human-input" />}
+            </>
+          }
+          metrics={[
+            {
+              label: 'Active session',
+              value: activeSession?.project ?? 'None',
+              detail: 'Current primary workstream',
+            },
+            {
+              label: 'Current phase',
+              value: activeSession?.phase ?? 'Idle',
+              detail: 'Latest visible runtime phase',
+            },
+            {
+              label: 'Open decisions',
+              value: String(openDecisions.length),
+              detail: 'Human choices still pending',
+            },
+            {
+              label: 'Health signals',
+              value: String(healthAttentionCount),
+              detail: 'Non-green health indicators',
+            },
+          ]}
+          motifs={
+            <>
+              <StatusMotif
+                kind="governance"
+                title="Governance remains in the foreground"
+                description="Decision count, health signals, and next steps are visible before users dive into lower-level detail."
+              />
+              <StatusMotif
+                kind="agent"
+                title="Agent activity stays legible"
+                description="The active session, phase flow, and current executor are readable as one operational story."
+              />
+              <StatusMotif
+                kind="human-loop"
+                title="Human checkpoints are prioritized"
+                description="Open decisions and guidance keep the operator focused on interventions that unlock progress."
+              />
+            </>
+          }
+          asideTitle="Operator focus"
+          asideDescription="Start here when you need the fastest possible understanding of current delivery state and the next action that needs a human response."
+          asideContent={
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <Activity className="size-4 text-info" /> What this page answers
+                </div>
+                <Text muted className="mt-1 text-xs">
+                  What is running, what is blocked, and what you should review next.
+                </Text>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <ShieldCheck className="size-4 text-info" /> Why it matters
+                </div>
+                <Text muted className="mt-1 text-xs">
+                  It keeps strategic oversight and runtime evidence together instead of splitting
+                  them across disconnected screens.
+                </Text>
+              </div>
+            </div>
+          }
         />
-      </section>
 
-      {/* Mini FlowTimeline */}
-      {phases.length > 0 && (
-        <section aria-label="Phase timeline">
-          <FlowTimeline
-            phases={phases}
-            activePhaseId={activeSession?.phase}
-            onPhaseClick={(phaseId) => {
-              if (activeSession) {
-                navigate(`/sessions/${encodeURIComponent(activeSession.id)}`);
-              }
-              // phaseId consumed by navigation
-              void phaseId;
-            }}
+        {/* Welcome Wizard — first-time users (M15-040) */}
+        {!wizardDismissed && <WelcomeWizard onDismiss={dismissWizard} />}
+
+        {shouldShowDiagnostics && (
+          <OnboardingDiagnosticsWizard
+            sessionId={activeSession?.id ?? null}
+            onDismiss={dismissDiagnostics}
+          />
+        )}
+
+        {/* What's Next — contextual guidance (M21-002) */}
+        <WhatsNextGuidance />
+
+        {/* Active Session Hero */}
+        <section aria-label="Active session">
+          <SessionStatus
+            session={sessionSummary}
+            progress={activeSession?.progress ?? 0}
+            activePhase={activeSession?.phase}
+            activeAgent={activeSession?.current_agent ?? undefined}
+            connectionStatus={connectionStatus}
           />
         </section>
-      )}
 
-      {/* Agent Activity Strip */}
-      {agentEntries.length > 0 && (
-        <section aria-label="Agent activity">
-          <Card elevation="flat" className="p-4">
-            <div className="flex items-center justify-between mb-3">
-              <Heading level={2} className="text-sm">
-                Agent Activity
-              </Heading>
-              <Button variant="ghost" size="xs" onClick={() => navigate('/agents')}>
-                View all <ArrowRight className="size-3 ml-1" />
-              </Button>
-            </div>
-            <AgentActivity
-              agents={agentEntries}
-              onAgentClick={() => {
+        {/* Mini FlowTimeline */}
+        {phases.length > 0 && (
+          <section aria-label="Phase timeline">
+            <FlowTimeline
+              phases={phases}
+              activePhaseId={activeSession?.phase}
+              onPhaseClick={(phaseId) => {
                 if (activeSession) {
                   navigate(`/sessions/${encodeURIComponent(activeSession.id)}`);
                 }
+                // phaseId consumed by navigation
+                void phaseId;
               }}
             />
-          </Card>
-        </section>
-      )}
+          </section>
+        )}
 
-      {/* Two-column: Open Decisions + Latest Artifacts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Open Decisions */}
-        <section aria-label="Open decisions">
-          <Card elevation="flat" className="p-4">
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2">
-                <Scale className="size-4" />
-                <span className="text-sm font-semibold">Open Decisions</span>
+        {/* Agent Activity Strip */}
+        {agentEntries.length > 0 && (
+          <section aria-label="Agent activity">
+            <Card elevation="flat" className="p-4">
+              <div className="flex items-center justify-between mb-3">
+                <Heading level={2} className="text-sm">
+                  Agent Activity
+                </Heading>
+                <Button variant="ghost" size="xs" onClick={() => navigate('/agents')}>
+                  View all <ArrowRight className="size-3 ml-1" />
+                </Button>
               </div>
-              <div className="flex items-center gap-2">
-                {openDecisions.length > 0 && (
-                  <ControlSignalBadge
-                    signal="needs-human-input"
-                    className="hidden sm:inline-flex"
-                  />
-                )}
-                <Badge variant="secondary">{openDecisions.length}</Badge>
-              </div>
-            </div>
-            {openDecisions.length === 0 ? (
-              <Text muted className="text-xs">
-                No open decisions
-              </Text>
-            ) : (
-              <ul className="space-y-2">
-                {openDecisions.slice(0, 5).map((d) => (
-                  <li key={d.id} className="text-xs flex items-start gap-2">
-                    <Badge
-                      variant={
-                        d.priority === 'HIGH'
-                          ? 'error'
-                          : d.priority === 'MEDIUM'
-                            ? 'warning'
-                            : 'secondary'
-                      }
-                      className="shrink-0 text-[10px]"
-                    >
-                      {d.priority}
-                    </Badge>
-                    <span className="min-w-0 truncate">{d.question}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
-            {openDecisions.length > 0 && (
-              <Button
-                variant="ghost"
-                size="xs"
-                className="mt-3"
-                onClick={() => navigate('/decisions')}
-              >
-                View all decisions <ArrowRight className="size-3 ml-1" />
-              </Button>
-            )}
-          </Card>
-        </section>
+              <AgentActivity
+                agents={agentEntries}
+                onAgentClick={() => {
+                  if (activeSession) {
+                    navigate(`/sessions/${encodeURIComponent(activeSession.id)}`);
+                  }
+                }}
+              />
+            </Card>
+          </section>
+        )}
 
-        {/* Latest Artifacts */}
-        <section aria-label="Latest artifacts">
-          <Card elevation="flat" className="p-4">
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2">
-                <Package className="size-4" />
-                <span className="text-sm font-semibold">Latest Artifacts</span>
+        {/* Two-column: Open Decisions + Latest Artifacts */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Open Decisions */}
+          <section aria-label="Open decisions">
+            <Card elevation="flat" className="p-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <Scale className="size-4" />
+                  <span className="text-sm font-semibold">Open Decisions</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {openDecisions.length > 0 && (
+                    <ControlSignalBadge
+                      signal="needs-human-input"
+                      className="hidden sm:inline-flex"
+                    />
+                  )}
+                  <Badge variant="secondary">{openDecisions.length}</Badge>
+                </div>
               </div>
-              <Badge variant="secondary">{artifactEvents.length}</Badge>
+              {openDecisions.length === 0 ? (
+                <Text muted className="text-xs">
+                  No open decisions
+                </Text>
+              ) : (
+                <ul className="space-y-2">
+                  {openDecisions.slice(0, 5).map((d) => (
+                    <li key={d.id} className="text-xs flex items-start gap-2">
+                      <Badge
+                        variant={
+                          d.priority === 'HIGH'
+                            ? 'error'
+                            : d.priority === 'MEDIUM'
+                              ? 'warning'
+                              : 'secondary'
+                        }
+                        className="shrink-0 text-[10px]"
+                      >
+                        {d.priority}
+                      </Badge>
+                      <span className="min-w-0 truncate">{d.question}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {openDecisions.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="mt-3"
+                  onClick={() => navigate('/decisions')}
+                >
+                  View all decisions <ArrowRight className="size-3 ml-1" />
+                </Button>
+              )}
+            </Card>
+          </section>
+
+          {/* Latest Artifacts */}
+          <section aria-label="Latest artifacts">
+            <Card elevation="flat" className="p-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <Package className="size-4" />
+                  <span className="text-sm font-semibold">Latest Artifacts</span>
+                </div>
+                <Badge variant="secondary">{artifactEvents.length}</Badge>
+              </div>
+              {artifactEvents.length === 0 ? (
+                <Text muted className="text-xs">
+                  No artifacts created yet
+                </Text>
+              ) : (
+                <ul className="space-y-1.5">
+                  {artifactEvents.slice(-5).map((e) => (
+                    <li key={e.id} className="text-xs flex items-start gap-2">
+                      <Package className="size-3 mt-0.5 shrink-0 text-muted-foreground" />
+                      <span>{e.description}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {artifactEvents.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="mt-3"
+                  onClick={() => navigate('/artifacts')}
+                >
+                  Browse artifacts <ArrowRight className="size-3 ml-1" />
+                </Button>
+              )}
+            </Card>
+          </section>
+        </div>
+
+        {/* System Health Compact Strip */}
+        {health && (
+          <section aria-label="System health">
+            <Heading level={2} className="mb-3 text-sm">
+              System Health
+            </Heading>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              {(Object.entries(health) as [string, HealthIndicator][]).map(([name, indicator]) => (
+                <HealthCard key={name} name={name} indicator={indicator} />
+              ))}
             </div>
-            {artifactEvents.length === 0 ? (
-              <Text muted className="text-xs">
-                No artifacts created yet
-              </Text>
-            ) : (
-              <ul className="space-y-1.5">
-                {artifactEvents.slice(-5).map((e) => (
-                  <li key={e.id} className="text-xs flex items-start gap-2">
-                    <Package className="size-3 mt-0.5 shrink-0 text-muted-foreground" />
-                    <span>{e.description}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
-            {artifactEvents.length > 0 && (
-              <Button
-                variant="ghost"
-                size="xs"
-                className="mt-3"
-                onClick={() => navigate('/artifacts')}
-              >
-                Browse artifacts <ArrowRight className="size-3 ml-1" />
-              </Button>
-            )}
-          </Card>
-        </section>
+          </section>
+        )}
+
+        {/* Idle CTA */}
+        {!activeSession && (
+          <section aria-label="Call to action">
+            <EmptyState
+              icon={<Rocket className="size-10" />}
+              title="No active session"
+              description="Start a CREATE or AUDIT command to begin."
+              action={{ label: 'Go to Commands', onClick: () => navigate('/commands') }}
+            />
+          </section>
+        )}
       </div>
-
-      {/* System Health Compact Strip */}
-      {health && (
-        <section aria-label="System health">
-          <Heading level={2} className="mb-3 text-sm">
-            System Health
-          </Heading>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            {(Object.entries(health) as [string, HealthIndicator][]).map(([name, indicator]) => (
-              <HealthCard key={name} name={name} indicator={indicator} />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Idle CTA */}
-      {!activeSession && (
-        <section aria-label="Call to action">
-          <EmptyState
-            icon={<Rocket className="size-10" />}
-            title="No active session"
-            description="Start a CREATE or AUDIT command to begin."
-            action={{ label: 'Go to Commands', onClick: () => navigate('/commands') }}
-          />
-        </section>
-      )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/webapp/ui/src/pages/sessions/session-detail-page.tsx
+++ b/src/webapp/ui/src/pages/sessions/session-detail-page.tsx
@@ -10,9 +10,8 @@ import { Heading, Text } from '@/components/ui/typography';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Spinner } from '@/components/ui/spinner';
-import { AlertBanner } from '@/components/ui/alert-banner';
 import { EmptyState } from '@/components/ui/empty-state';
+import { PageShell } from '@/components/ui/page-shell';
 import { MissionControlHero } from '@/components/ui/mission-control-hero';
 import { StatusMotif } from '@/components/ui/status-motif';
 import { ControlSignalBadge } from '@/components/ui/control-signal';
@@ -41,7 +40,6 @@ import {
   Scale,
   Lightbulb,
   ShieldAlert,
-  RefreshCw,
 } from 'lucide-react';
 
 /* ── Status badge config ── */
@@ -219,43 +217,27 @@ export default function SessionDetailPage() {
     [phaseFilter]
   );
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Loading session…" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-6">
-        <AlertBanner variant="error">
-          <div className="flex items-center justify-between gap-4 w-full">
-            <span>Failed to load session: {(error as Error).message}</span>
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="size-3 mr-1.5" /> Retry
-            </Button>
-          </div>
-        </AlertBanner>
-      </div>
-    );
-  }
-
   if (!session) {
     return (
-      <div className="p-6">
-        <EmptyState
-          icon={<Activity className="size-8" />}
-          title="Session not found"
-          description="This session may have been removed or the ID is invalid."
-        />
-        <div className="mt-4 flex justify-center">
-          <Button variant="outline" onClick={() => navigate('/sessions')}>
-            <ArrowLeft className="size-4 mr-2" /> Back to Sessions
-          </Button>
+      <PageShell
+        isLoading={isLoading}
+        loadingLabel="Loading session…"
+        error={error as Error | null}
+        onRetry={() => refetch()}
+      >
+        <div className="p-6">
+          <EmptyState
+            icon={<Activity className="size-8" />}
+            title="Session not found"
+            description="This session may have been removed or the ID is invalid."
+          />
+          <div className="mt-4 flex justify-center">
+            <Button variant="outline" onClick={() => navigate('/sessions')}>
+              <ArrowLeft className="size-4 mr-2" /> Back to Sessions
+            </Button>
+          </div>
         </div>
-      </div>
+      </PageShell>
     );
   }
 
@@ -292,300 +274,309 @@ export default function SessionDetailPage() {
   ];
 
   return (
-    <div className="p-6 space-y-6" data-testid="session-detail-page">
-      <PageHeader
-        title={session.project}
-        subtitle="Session detail shows live phase progression, agent ownership, and evidence signals in one operational view."
-        chips={[
-          {
-            id: 'status',
-            label: session.status,
-            tone:
-              config.variant === 'error'
-                ? 'critical'
-                : config.variant === 'warning'
-                  ? 'warning'
-                  : config.variant === 'success'
-                    ? 'success'
-                    : 'info',
-          },
-          { id: 'progress', label: `${Math.round(session.progress)}% progress`, tone: 'info' },
-          {
-            id: 'gate-failures',
-            label: `${gateFailuresCount} gate failures`,
-            tone: gateFailuresCount > 0 ? 'warning' : 'success',
-          },
-        ]}
-        actions={
-          <Button
-            variant="outline"
-            size="sm"
-            className="motion-transition-base"
-            onClick={() => navigate('/sessions')}
-          >
-            <ArrowLeft className="mr-1 size-3" /> Back to Runs
-          </Button>
-        }
-      />
-
-      <ContextStrip items={contextItems} />
-
-      <MissionControlHero
-        eyebrow="Session runtime"
-        title={`${session.project} is running as a governed execution record`}
-        description="Use this detail view to inspect the live phase, the active agent, produced evidence, and any failure or escalation that requires human intervention."
-        badges={
-          <>
-            <ControlSignalBadge signal="governed" />
-            {session.current_agent && <ControlSignalBadge signal="active-agent" />}
-            {gateFailuresCount > 0 && <ControlSignalBadge signal="needs-human-input" />}
-            <Badge variant={config.variant} className="gap-1">
-              {config.icon}
-              {session.status}
-            </Badge>
-          </>
-        }
-        metrics={[
-          { label: 'Flow', value: session.flow, detail: 'Execution mode for this session' },
-          { label: 'Current phase', value: session.phase, detail: 'Where the run is now' },
-          { label: 'Active agent', value: activeAgent, detail: 'Current responsible executor' },
-          {
-            label: 'Progress',
-            value: `${Math.round(session.progress)}%`,
-            detail: 'Observed completion',
-          },
-        ]}
-        motifs={
-          <>
-            <StatusMotif
-              kind="governance"
-              title="Runtime evidence stays attached"
-              description="Artifacts, decisions, and logs remain tied to the session instead of being scattered across views."
-            />
-            <StatusMotif
-              kind="agent"
-              title="Agent execution is inspectable"
-              description="Each agent card opens context, retries, and current work so intervention is evidence-based."
-            />
-            <StatusMotif
-              kind="human-loop"
-              title="Failure states call for a person"
-              description="Gate failures and blocked steps are surfaced as visible operational interruptions that need review."
-            />
-          </>
-        }
-        asideTitle="Session control"
-        asideDescription="Move from phase timeline to agent activity, then inspect artifacts, decisions, and the runtime log for the evidence behind the current state."
-        asideContent={
-          <div className="space-y-3">
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading session…"
+      error={error as Error | null}
+      onRetry={() => refetch()}
+    >
+      <div className="p-6 space-y-6" data-testid="session-detail-page">
+        <PageHeader
+          title={session.project}
+          subtitle="Session detail shows live phase progression, agent ownership, and evidence signals in one operational view."
+          chips={[
+            {
+              id: 'status',
+              label: session.status,
+              tone:
+                config.variant === 'error'
+                  ? 'critical'
+                  : config.variant === 'warning'
+                    ? 'warning'
+                    : config.variant === 'success'
+                      ? 'success'
+                      : 'info',
+            },
+            { id: 'progress', label: `${Math.round(session.progress)}% progress`, tone: 'info' },
+            {
+              id: 'gate-failures',
+              label: `${gateFailuresCount} gate failures`,
+              tone: gateFailuresCount > 0 ? 'warning' : 'success',
+            },
+          ]}
+          actions={
             <Button
               variant="outline"
-              className="w-full justify-between"
+              size="sm"
+              className="motion-transition-base"
               onClick={() => navigate('/sessions')}
             >
-              <span className="inline-flex items-center gap-2">
-                <ArrowLeft className="size-4" />
-                Back to Sessions
-              </span>
+              <ArrowLeft className="mr-1 size-3" /> Back to Runs
             </Button>
-            <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                Evidence counts
-              </div>
-              <Text muted className="mt-2 text-xs">
-                {artifactCount} artifact signal(s), {decisionCount} decision event(s),{' '}
-                {gateFailuresCount} gate failure event(s).
-              </Text>
-            </div>
-          </div>
-        }
-      />
-
-      {/* Flow Timeline (top) — M15-034: phase click filters log */}
-      <section aria-label="Phase timeline">
-        <FlowTimeline
-          phases={phases}
-          activePhaseId={session.phase}
-          onPhaseClick={handlePhaseClick}
+          }
         />
-        {phaseFilter && (
-          <div className="mt-2 flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs">
-              Filtering: {phaseFilter}
-            </Badge>
-            <button
-              type="button"
-              onClick={() => setPhaseFilter(null)}
-              className="text-xs text-muted-foreground underline hover:text-foreground"
-            >
-              Clear filter
-            </button>
-          </div>
-        )}
-      </section>
 
-      {/* M27-002: Execution Timeline with replay */}
-      {mergedLogEvents.length > 0 && (
-        <section aria-label="Execution timeline">
-          <ExecutionTimeline
-            events={mergedLogEvents.map((e) => ({
-              id: e.id,
-              type: e.type,
-              timestamp: e.timestamp,
-              description: e.description,
-              agent: e.agent,
-              phase: e.phase,
-              artifact_id: e.artifactId,
-            }))}
-          />
-        </section>
-      )}
+        <ContextStrip items={contextItems} />
 
-      {/* Three-column layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* Left: Agent Activity (40%) — M15-035: live agent data */}
-        <section aria-label="Agent activity" className="lg:col-span-5">
-          <Card elevation="flat" className="p-4">
-            <Heading level={2} className="mb-3 text-sm">
-              Agent Activity
-            </Heading>
-            <AgentActivity
-              agents={agentEntries}
-              onAgentClick={(agentId) => {
-                const agent = agents.find((a) => a.id === agentId);
-                if (agent) {
-                  setExplainAgent(explainAgent?.id === agentId ? null : agent);
-                  setGateFailure(null);
-                }
-              }}
-            />
-          </Card>
-        </section>
-
-        {/* Middle: Artifacts + Decisions (35%) — M15-038: artifact flash */}
-        <section aria-label="Artifacts and decisions" className="lg:col-span-4 space-y-4">
-          {/* Artifacts */}
-          <Card elevation="flat" className="p-4">
-            <div className="flex items-center gap-2 mb-3">
-              <Package className="size-4" />
-              <span className="text-sm font-semibold">Artifacts</span>
-              <Badge variant="secondary" className="ml-auto">
-                {artifactEvents.length}
+        <MissionControlHero
+          eyebrow="Session runtime"
+          title={`${session.project} is running as a governed execution record`}
+          description="Use this detail view to inspect the live phase, the active agent, produced evidence, and any failure or escalation that requires human intervention."
+          badges={
+            <>
+              <ControlSignalBadge signal="governed" />
+              {session.current_agent && <ControlSignalBadge signal="active-agent" />}
+              {gateFailuresCount > 0 && <ControlSignalBadge signal="needs-human-input" />}
+              <Badge variant={config.variant} className="gap-1">
+                {config.icon}
+                {session.status}
               </Badge>
-            </div>
-            {artifactEvents.length === 0 ? (
-              <Text muted className="text-xs">
-                No artifacts created yet
-              </Text>
-            ) : (
-              <ul className="space-y-1.5">
-                {artifactEvents.map((e, i) => (
-                  <li
-                    key={e.id}
-                    className={`text-xs flex items-start gap-2 ${i === artifactEvents.length - 1 ? 'animate-flash' : ''}`}
-                  >
-                    <Package className="size-3 mt-0.5 shrink-0 text-muted-foreground" />
-                    <span>{e.description}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Card>
-
-          {/* Decisions */}
-          <Card elevation="flat" className="p-4">
-            <div className="flex items-center gap-2 mb-3">
-              <Scale className="size-4" />
-              <span className="text-sm font-semibold">Decisions</span>
-              <Badge variant="secondary" className="ml-auto">
-                {decisionEvents.length}
-              </Badge>
-            </div>
-            {decisionEvents.length === 0 ? (
-              <Text muted className="text-xs">
-                No decisions recorded yet
-              </Text>
-            ) : (
-              <ul className="space-y-1.5">
-                {decisionEvents.map((e) => (
-                  <li key={e.id} className="text-xs flex items-start gap-2">
-                    <Scale className="size-3 mt-0.5 shrink-0 text-muted-foreground" />
-                    <span>{e.description}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Card>
-        </section>
-
-        {/* Right: Explainability Panel (25%) — M15-037: gate failure panel */}
-        <section className="lg:col-span-3" aria-label="Detail panel">
-          {gateFailure ? (
-            <ExplainabilityPanel
-              title="Gate Failed"
-              reason={gateFailure.reason}
-              suggestedAction={gateFailure.suggestedAction}
-              details={{
-                Phase: gateFailure.phase,
-                Violations: String(gateFailure.violations),
-                ...(gateFailure.unmetCriteria && gateFailure.unmetCriteria.length > 0
-                  ? {
-                      'Unmet Exit Criteria': gateFailure.unmetCriteria.join('; '),
-                    }
-                  : {}),
-                Time: new Date(gateFailure.timestamp).toLocaleTimeString(),
-                ...(gateFailure.relatedArtifactId
-                  ? { Artifact: gateFailure.relatedArtifactId }
-                  : {}),
-              }}
-              onDismiss={() => setGateFailure(null)}
-            />
-          ) : explainAgent ? (
-            <ExplainabilityPanel
-              title={`Agent: ${explainAgent.name}`}
-              reason={explainAgent.task_description}
-              suggestedAction={explainAgent.status === 'failed' ? 'Review error logs' : undefined}
-              details={{
-                Status: explainAgent.status,
-                Phase: explainAgent.phase,
-                Retries: String(explainAgent.retry_count),
-                ...(explainAgent.duration_ms > 0
-                  ? { Duration: `${(explainAgent.duration_ms / 1000).toFixed(1)}s` }
-                  : {}),
-              }}
-              onDismiss={() => setExplainAgent(null)}
-            />
-          ) : latestGateFailure ? (
-            <Card
-              elevation="flat"
-              className="p-4 border-red-500/30 bg-red-500/5 cursor-pointer hover:shadow-md"
-              clickable
-              onClick={() => handleGateFailureShow(latestGateFailure)}
-            >
-              <div className="flex items-center gap-2 text-red-600">
-                <ShieldAlert className="size-4" />
-                <Text className="text-xs font-medium">Gate failure detected — click to review</Text>
-              </div>
-            </Card>
-          ) : (
-            <Card elevation="flat" className="p-4">
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <Lightbulb className="size-4" />
-                <Text muted className="text-xs">
-                  Click an agent to view details
+            </>
+          }
+          metrics={[
+            { label: 'Flow', value: session.flow, detail: 'Execution mode for this session' },
+            { label: 'Current phase', value: session.phase, detail: 'Where the run is now' },
+            { label: 'Active agent', value: activeAgent, detail: 'Current responsible executor' },
+            {
+              label: 'Progress',
+              value: `${Math.round(session.progress)}%`,
+              detail: 'Observed completion',
+            },
+          ]}
+          motifs={
+            <>
+              <StatusMotif
+                kind="governance"
+                title="Runtime evidence stays attached"
+                description="Artifacts, decisions, and logs remain tied to the session instead of being scattered across views."
+              />
+              <StatusMotif
+                kind="agent"
+                title="Agent execution is inspectable"
+                description="Each agent card opens context, retries, and current work so intervention is evidence-based."
+              />
+              <StatusMotif
+                kind="human-loop"
+                title="Failure states call for a person"
+                description="Gate failures and blocked steps are surfaced as visible operational interruptions that need review."
+              />
+            </>
+          }
+          asideTitle="Session control"
+          asideDescription="Move from phase timeline to agent activity, then inspect artifacts, decisions, and the runtime log for the evidence behind the current state."
+          asideContent={
+            <div className="space-y-3">
+              <Button
+                variant="outline"
+                className="w-full justify-between"
+                onClick={() => navigate('/sessions')}
+              >
+                <span className="inline-flex items-center gap-2">
+                  <ArrowLeft className="size-4" />
+                  Back to Sessions
+                </span>
+              </Button>
+              <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Evidence counts
+                </div>
+                <Text muted className="mt-2 text-xs">
+                  {artifactCount} artifact signal(s), {decisionCount} decision event(s),{' '}
+                  {gateFailuresCount} gate failure event(s).
                 </Text>
               </div>
-            </Card>
+            </div>
+          }
+        />
+
+        {/* Flow Timeline (top) — M15-034: phase click filters log */}
+        <section aria-label="Phase timeline">
+          <FlowTimeline
+            phases={phases}
+            activePhaseId={session.phase}
+            onPhaseClick={handlePhaseClick}
+          />
+          {phaseFilter && (
+            <div className="mt-2 flex items-center gap-2">
+              <Badge variant="secondary" className="text-xs">
+                Filtering: {phaseFilter}
+              </Badge>
+              <button
+                type="button"
+                onClick={() => setPhaseFilter(null)}
+                className="text-xs text-muted-foreground underline hover:text-foreground"
+              >
+                Clear filter
+              </button>
+            </div>
           )}
         </section>
-      </div>
 
-      {/* Bottom: Runtime Log — M15-036: merged query + SSE events */}
-      <section aria-label="Runtime log">
-        <Card elevation="flat" className="p-4">
-          <RuntimeLog events={filteredLogEvents} maxVisible={50} />
-        </Card>
-      </section>
-    </div>
+        {/* M27-002: Execution Timeline with replay */}
+        {mergedLogEvents.length > 0 && (
+          <section aria-label="Execution timeline">
+            <ExecutionTimeline
+              events={mergedLogEvents.map((e) => ({
+                id: e.id,
+                type: e.type,
+                timestamp: e.timestamp,
+                description: e.description,
+                agent: e.agent,
+                phase: e.phase,
+                artifact_id: e.artifactId,
+              }))}
+            />
+          </section>
+        )}
+
+        {/* Three-column layout */}
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+          {/* Left: Agent Activity (40%) — M15-035: live agent data */}
+          <section aria-label="Agent activity" className="lg:col-span-5">
+            <Card elevation="flat" className="p-4">
+              <Heading level={2} className="mb-3 text-sm">
+                Agent Activity
+              </Heading>
+              <AgentActivity
+                agents={agentEntries}
+                onAgentClick={(agentId) => {
+                  const agent = agents.find((a) => a.id === agentId);
+                  if (agent) {
+                    setExplainAgent(explainAgent?.id === agentId ? null : agent);
+                    setGateFailure(null);
+                  }
+                }}
+              />
+            </Card>
+          </section>
+
+          {/* Middle: Artifacts + Decisions (35%) — M15-038: artifact flash */}
+          <section aria-label="Artifacts and decisions" className="lg:col-span-4 space-y-4">
+            {/* Artifacts */}
+            <Card elevation="flat" className="p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Package className="size-4" />
+                <span className="text-sm font-semibold">Artifacts</span>
+                <Badge variant="secondary" className="ml-auto">
+                  {artifactEvents.length}
+                </Badge>
+              </div>
+              {artifactEvents.length === 0 ? (
+                <Text muted className="text-xs">
+                  No artifacts created yet
+                </Text>
+              ) : (
+                <ul className="space-y-1.5">
+                  {artifactEvents.map((e, i) => (
+                    <li
+                      key={e.id}
+                      className={`text-xs flex items-start gap-2 ${i === artifactEvents.length - 1 ? 'animate-flash' : ''}`}
+                    >
+                      <Package className="size-3 mt-0.5 shrink-0 text-muted-foreground" />
+                      <span>{e.description}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+
+            {/* Decisions */}
+            <Card elevation="flat" className="p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Scale className="size-4" />
+                <span className="text-sm font-semibold">Decisions</span>
+                <Badge variant="secondary" className="ml-auto">
+                  {decisionEvents.length}
+                </Badge>
+              </div>
+              {decisionEvents.length === 0 ? (
+                <Text muted className="text-xs">
+                  No decisions recorded yet
+                </Text>
+              ) : (
+                <ul className="space-y-1.5">
+                  {decisionEvents.map((e) => (
+                    <li key={e.id} className="text-xs flex items-start gap-2">
+                      <Scale className="size-3 mt-0.5 shrink-0 text-muted-foreground" />
+                      <span>{e.description}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+          </section>
+
+          {/* Right: Explainability Panel (25%) — M15-037: gate failure panel */}
+          <section className="lg:col-span-3" aria-label="Detail panel">
+            {gateFailure ? (
+              <ExplainabilityPanel
+                title="Gate Failed"
+                reason={gateFailure.reason}
+                suggestedAction={gateFailure.suggestedAction}
+                details={{
+                  Phase: gateFailure.phase,
+                  Violations: String(gateFailure.violations),
+                  ...(gateFailure.unmetCriteria && gateFailure.unmetCriteria.length > 0
+                    ? {
+                        'Unmet Exit Criteria': gateFailure.unmetCriteria.join('; '),
+                      }
+                    : {}),
+                  Time: new Date(gateFailure.timestamp).toLocaleTimeString(),
+                  ...(gateFailure.relatedArtifactId
+                    ? { Artifact: gateFailure.relatedArtifactId }
+                    : {}),
+                }}
+                onDismiss={() => setGateFailure(null)}
+              />
+            ) : explainAgent ? (
+              <ExplainabilityPanel
+                title={`Agent: ${explainAgent.name}`}
+                reason={explainAgent.task_description}
+                suggestedAction={explainAgent.status === 'failed' ? 'Review error logs' : undefined}
+                details={{
+                  Status: explainAgent.status,
+                  Phase: explainAgent.phase,
+                  Retries: String(explainAgent.retry_count),
+                  ...(explainAgent.duration_ms > 0
+                    ? { Duration: `${(explainAgent.duration_ms / 1000).toFixed(1)}s` }
+                    : {}),
+                }}
+                onDismiss={() => setExplainAgent(null)}
+              />
+            ) : latestGateFailure ? (
+              <Card
+                elevation="flat"
+                className="p-4 border-red-500/30 bg-red-500/5 cursor-pointer hover:shadow-md"
+                clickable
+                onClick={() => handleGateFailureShow(latestGateFailure)}
+              >
+                <div className="flex items-center gap-2 text-red-600">
+                  <ShieldAlert className="size-4" />
+                  <Text className="text-xs font-medium">
+                    Gate failure detected — click to review
+                  </Text>
+                </div>
+              </Card>
+            ) : (
+              <Card elevation="flat" className="p-4">
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Lightbulb className="size-4" />
+                  <Text muted className="text-xs">
+                    Click an agent to view details
+                  </Text>
+                </div>
+              </Card>
+            )}
+          </section>
+        </div>
+
+        {/* Bottom: Runtime Log — M15-036: merged query + SSE events */}
+        <section aria-label="Runtime log">
+          <Card elevation="flat" className="p-4">
+            <RuntimeLog events={filteredLogEvents} maxVisible={50} />
+          </Card>
+        </section>
+      </div>
+    </PageShell>
   );
 }

--- a/src/webapp/ui/src/pages/sessions/sessions-page.tsx
+++ b/src/webapp/ui/src/pages/sessions/sessions-page.tsx
@@ -7,26 +7,17 @@ import { Text } from '@/components/ui/typography';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Spinner } from '@/components/ui/spinner';
-import { AlertBanner } from '@/components/ui/alert-banner';
 import { ProgressBar } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
 import { MissionControlHero } from '@/components/ui/mission-control-hero';
 import { StatusMotif } from '@/components/ui/status-motif';
 import { PageHeader } from '@/components/layout/page-header';
 import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
+import { PageShell } from '@/components/ui/page-shell';
+import { QueueTriageList, type QueueTriageItem } from '@/components/ui/queue-triage-list';
 import { useSessions } from '@/hooks';
 import type { SessionStatus } from '@/lib/api-types';
-import {
-  Activity,
-  ArrowRight,
-  CheckCircle,
-  Clock,
-  Pause,
-  RefreshCw,
-  Sparkles,
-  XCircle,
-} from 'lucide-react';
+import { Activity, ArrowRight, CheckCircle, Clock, Pause, Sparkles, XCircle } from 'lucide-react';
 
 const statusConfig: Record<
   SessionStatus,
@@ -84,29 +75,6 @@ export default function SessionsPage() {
   const { data, isLoading, error, refetch } = useSessions();
   const navigate = useNavigate();
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Loading sessions…" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-6">
-        <AlertBanner variant="error">
-          <div className="flex items-center justify-between gap-4 w-full">
-            <span>Failed to load sessions: {(error as Error).message}</span>
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="size-3 mr-1.5" /> Retry
-            </Button>
-          </div>
-        </AlertBanner>
-      </div>
-    );
-  }
-
   const sessions = data?.sessions ?? [];
   const nextStep = getSessionGuidance(sessions);
   const activeSessions = sessions.filter((session) => session.status === 'active').length;
@@ -147,159 +115,143 @@ export default function SessionsPage() {
       ? `${Math.round(Math.max(...sessions.map((session) => session.progress)))}%`
       : '0%';
 
+  const queueItems = sessions.slice(0, 6).map<QueueTriageItem>((session) => ({
+    id: session.id,
+    title: session.project,
+    subtitle: `${session.flow} · ${session.phase}`,
+    statusLabel: session.status,
+    statusTone:
+      session.status === 'failed'
+        ? 'critical'
+        : session.status === 'paused'
+          ? 'warning'
+          : session.status === 'active'
+            ? 'info'
+            : 'success',
+    priority: session.status === 'failed' ? 'high' : session.status === 'paused' ? 'medium' : 'low',
+    icon: statusConfig[session.status].icon,
+    actionLabel: 'Open run',
+    meta: [
+      {
+        id: `${session.id}-progress`,
+        label: 'Progress',
+        value: `${Math.round(session.progress)}%`,
+      },
+      {
+        id: `${session.id}-agent`,
+        label: 'Agent',
+        value: session.current_agent ?? 'Unassigned',
+        tone: session.current_agent ? 'success' : 'neutral',
+      },
+    ],
+  }));
+
   return (
-    <div className="p-6 space-y-6" data-testid="sessions-page">
-      <PageHeader
-        title="Runs"
-        subtitle="Inspect active and historical orchestration sessions with clear runtime status and next-step guidance."
-        chips={[
-          {
-            id: 'runs-total',
-            label: `${sessions.length} total`,
-            tone: sessions.length > 0 ? 'info' : 'default',
-          },
-          { id: 'runs-active', label: `${activeSessions} active`, tone: 'success' },
-          {
-            id: 'runs-attention',
-            label: `${attentionSessions} need attention`,
-            tone: attentionSessions > 0 ? 'warning' : 'success',
-          },
-        ]}
-        actions={
-          <Button
-            variant="outline"
-            size="sm"
-            className="motion-transition-base"
-            onClick={() => navigate(nextStep.actionHref)}
-          >
-            {nextStep.actionLabel}
-            <ArrowRight className="ml-1 size-3" />
-          </Button>
-        }
-      />
-
-      <ContextStrip items={contextItems} />
-
-      <MissionControlHero
-        eyebrow="Execution archive"
-        title="Sessions turn orchestration into reviewable evidence"
-        description="Use this page as the runtime ledger for active and completed cycles, with clear signals for where work is live, stalled, or ready for review."
-        badges={<Badge variant="outline">Sessions</Badge>}
-        metrics={[
-          {
-            label: 'Active runs',
-            value: String(activeSessions),
-            detail: 'Current workstreams in progress',
-          },
-          {
-            label: 'Completed',
-            value: String(completedSessions),
-            detail: 'Finished orchestration cycles',
-          },
-          {
-            label: 'Needs attention',
-            value: String(attentionSessions),
-            detail: 'Paused or failed runs',
-          },
-          { label: 'Top progress', value: topProgress, detail: 'Highest visible completion level' },
-        ]}
-        motifs={
-          <>
-            <StatusMotif
-              kind="governance"
-              title="Sessions preserve traceability"
-              description="Every cycle can be reopened to review decisions, outcomes, and the path taken through the SDLC."
-            />
-            <StatusMotif
-              kind="agent"
-              title="Execution remains attributable"
-              description="Current agent ownership stays visible so the operator knows who is acting in each run."
-            />
-            <StatusMotif
-              kind="human-loop"
-              title="Escalated work stays recoverable"
-              description="Paused and failed sessions remain easy to find, inspect, and resume with the right human intervention."
-            />
-          </>
-        }
-        asideTitle="Selection logic"
-        asideDescription="Start with active runs, then inspect paused or failed sessions before using completed sessions for context and evidence."
-        asideContent={
-          <div className="space-y-3">
-            <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                Recommended now
-              </div>
-              <div className="mt-2 text-sm font-medium">{nextStep.title}</div>
-              <Text muted className="mt-1 text-xs">
-                {nextStep.description}
-              </Text>
-            </div>
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading sessions…"
+      error={error as Error | null}
+      onRetry={() => refetch()}
+      emptyState={{
+        icon: <Activity className="size-8" />,
+        title: 'No sessions',
+        description:
+          'Sessions appear after you start a command. Use Commands to launch a cycle, then come back here to follow it.',
+      }}
+    >
+      <div className="p-6 space-y-6" data-testid="sessions-page">
+        <PageHeader
+          title="Runs"
+          subtitle="Inspect active and historical orchestration sessions with clear runtime status and next-step guidance."
+          chips={[
+            {
+              id: 'runs-total',
+              label: `${sessions.length} total`,
+              tone: sessions.length > 0 ? 'info' : 'default',
+            },
+            { id: 'runs-active', label: `${activeSessions} active`, tone: 'success' },
+            {
+              id: 'runs-attention',
+              label: `${attentionSessions} need attention`,
+              tone: attentionSessions > 0 ? 'warning' : 'success',
+            },
+          ]}
+          actions={
             <Button
-              className="w-full justify-between"
               variant="outline"
+              size="sm"
+              className="motion-transition-base"
               onClick={() => navigate(nextStep.actionHref)}
             >
               {nextStep.actionLabel}
-              <ArrowRight className="size-4" />
+              <ArrowRight className="ml-1 size-3" />
             </Button>
-          </div>
-        }
-      />
+          }
+        />
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
-        <Card elevation="flat" className="border border-border/70 px-5 py-5">
-          <div className="flex items-start gap-3">
-            <Sparkles className="mt-0.5 size-5 text-info" />
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="font-semibold">How to use Sessions</span>
-                <Badge variant="outline">Session guide</Badge>
-              </div>
-              <div className="mt-4 grid gap-3 md:grid-cols-3">
-                <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
-                  <Badge variant="secondary">1</Badge>
-                  <div className="mt-3 font-medium">Find the active run</div>
-                  <Text muted className="mt-1 text-xs">
-                    Sessions marked `active` are the best starting point when you want to continue
-                    ongoing work.
-                  </Text>
-                </div>
-                <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
-                  <Badge variant="secondary">2</Badge>
-                  <div className="mt-3 font-medium">Open the detail view</div>
-                  <Text muted className="mt-1 text-xs">
-                    Click a session card to inspect current agent, timeline, and deeper execution
-                    context.
-                  </Text>
-                </div>
-                <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
-                  <Badge variant="secondary">3</Badge>
-                  <div className="mt-3 font-medium">Use progress to prioritize</div>
-                  <Text muted className="mt-1 text-xs">
-                    A higher completion percentage usually means you are closer to a decision, gate,
-                    or release moment.
-                  </Text>
-                </div>
-              </div>
-            </div>
-          </div>
-        </Card>
+        <ContextStrip items={contextItems} />
 
-        <Card elevation="flat" className="border border-border/70 px-5 py-5">
-          <div className="flex items-start gap-3">
-            <Activity className="mt-0.5 size-5 text-info" />
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="font-semibold">Recommended next step</span>
-                <Badge variant="info">{nextStep.badge}</Badge>
+        <MissionControlHero
+          eyebrow="Execution archive"
+          title="Sessions turn orchestration into reviewable evidence"
+          description="Use this page as the runtime ledger for active and completed cycles, with clear signals for where work is live, stalled, or ready for review."
+          badges={<Badge variant="outline">Sessions</Badge>}
+          metrics={[
+            {
+              label: 'Active runs',
+              value: String(activeSessions),
+              detail: 'Current workstreams in progress',
+            },
+            {
+              label: 'Completed',
+              value: String(completedSessions),
+              detail: 'Finished orchestration cycles',
+            },
+            {
+              label: 'Needs attention',
+              value: String(attentionSessions),
+              detail: 'Paused or failed runs',
+            },
+            {
+              label: 'Top progress',
+              value: topProgress,
+              detail: 'Highest visible completion level',
+            },
+          ]}
+          motifs={
+            <>
+              <StatusMotif
+                kind="governance"
+                title="Sessions preserve traceability"
+                description="Every cycle can be reopened to review decisions, outcomes, and the path taken through the SDLC."
+              />
+              <StatusMotif
+                kind="agent"
+                title="Execution remains attributable"
+                description="Current agent ownership stays visible so the operator knows who is acting in each run."
+              />
+              <StatusMotif
+                kind="human-loop"
+                title="Escalated work stays recoverable"
+                description="Paused and failed sessions remain easy to find, inspect, and resume with the right human intervention."
+              />
+            </>
+          }
+          asideTitle="Selection logic"
+          asideDescription="Start with active runs, then inspect paused or failed sessions before using completed sessions for context and evidence."
+          asideContent={
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-border/60 bg-background/70 px-4 py-3">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Recommended now
+                </div>
+                <div className="mt-2 text-sm font-medium">{nextStep.title}</div>
+                <Text muted className="mt-1 text-xs">
+                  {nextStep.description}
+                </Text>
               </div>
-              <div className="mt-3 text-sm font-medium">{nextStep.title}</div>
-              <Text muted className="mt-1 text-sm">
-                {nextStep.description}
-              </Text>
               <Button
-                className="mt-4"
+                className="w-full justify-between"
                 variant="outline"
                 onClick={() => navigate(nextStep.actionHref)}
               >
@@ -307,64 +259,137 @@ export default function SessionsPage() {
                 <ArrowRight className="size-4" />
               </Button>
             </div>
-          </div>
-        </Card>
-      </div>
-
-      {/* Session list */}
-      {sessions.length === 0 ? (
-        <EmptyState
-          icon={<Activity className="size-8" />}
-          title="No sessions"
-          description="Sessions appear after you start a command. Use Commands to launch a cycle, then come back here to follow it."
+          }
         />
-      ) : (
-        <div className="space-y-3">
-          {sessions.map((session) => {
-            const config = statusConfig[session.status];
-            return (
-              <Card
-                key={session.id}
-                clickable
-                onClick={() => navigate(`/sessions/${encodeURIComponent(session.id)}`)}
-                elevation="outlined"
-                className="transition-colors hover:border-primary/50"
-              >
-                <div className="flex items-center justify-between gap-4">
-                  <div className="flex items-center gap-3 min-w-0">
-                    <Badge variant={config.variant} className="gap-1 shrink-0">
-                      {config.icon}
-                      {session.status}
-                    </Badge>
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold truncate">{session.project}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {session.flow} &middot; {session.phase}
-                      </p>
-                    </div>
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
+          <Card elevation="flat" className="border border-border/70 px-5 py-5">
+            <div className="flex items-start gap-3">
+              <Sparkles className="mt-0.5 size-5 text-info" />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold">How to use Sessions</span>
+                  <Badge variant="outline">Session guide</Badge>
+                </div>
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
+                    <Badge variant="secondary">1</Badge>
+                    <div className="mt-3 font-medium">Find the active run</div>
+                    <Text muted className="mt-1 text-xs">
+                      Sessions marked `active` are the best starting point when you want to continue
+                      ongoing work.
+                    </Text>
                   </div>
-                  <div className="flex items-center gap-4 shrink-0">
-                    <div className="w-32 hidden sm:block">
-                      <ProgressBar value={session.progress} showPercentage />
-                    </div>
-                    <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                      <Clock className="size-3" />
-                      <time dateTime={session.started_at}>
-                        {new Date(session.started_at).toLocaleDateString()}
-                      </time>
-                    </div>
+                  <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
+                    <Badge variant="secondary">2</Badge>
+                    <div className="mt-3 font-medium">Open the detail view</div>
+                    <Text muted className="mt-1 text-xs">
+                      Click a session card to inspect current agent, timeline, and deeper execution
+                      context.
+                    </Text>
+                  </div>
+                  <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
+                    <Badge variant="secondary">3</Badge>
+                    <div className="mt-3 font-medium">Use progress to prioritize</div>
+                    <Text muted className="mt-1 text-xs">
+                      A higher completion percentage usually means you are closer to a decision,
+                      gate, or release moment.
+                    </Text>
                   </div>
                 </div>
-                {session.current_agent && (
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Current agent: <span className="font-medium">{session.current_agent}</span>
-                  </p>
-                )}
-              </Card>
-            );
-          })}
+              </div>
+            </div>
+          </Card>
+
+          <Card elevation="flat" className="border border-border/70 px-5 py-5">
+            <div className="flex items-start gap-3">
+              <Activity className="mt-0.5 size-5 text-info" />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold">Recommended next step</span>
+                  <Badge variant="info">{nextStep.badge}</Badge>
+                </div>
+                <div className="mt-3 text-sm font-medium">{nextStep.title}</div>
+                <Text muted className="mt-1 text-sm">
+                  {nextStep.description}
+                </Text>
+                <Button
+                  className="mt-4"
+                  variant="outline"
+                  onClick={() => navigate(nextStep.actionHref)}
+                >
+                  {nextStep.actionLabel}
+                  <ArrowRight className="size-4" />
+                </Button>
+              </div>
+            </div>
+          </Card>
         </div>
-      )}
-    </div>
+
+        <QueueTriageList
+          title="Runs queue"
+          description="Triage active and attention-required runs with one consistent operational card pattern."
+          items={queueItems}
+          emptyTitle="No runs queued"
+          emptyDescription="Queue a command to start the first run."
+          onItemAction={(sessionId) => navigate(`/sessions/${encodeURIComponent(sessionId)}`)}
+        />
+
+        {/* Session list */}
+        {sessions.length === 0 ? (
+          <EmptyState
+            icon={<Activity className="size-8" />}
+            title="No sessions"
+            description="Sessions appear after you start a command. Use Commands to launch a cycle, then come back here to follow it."
+          />
+        ) : (
+          <div className="space-y-3">
+            {sessions.map((session) => {
+              const config = statusConfig[session.status];
+              return (
+                <Card
+                  key={session.id}
+                  clickable
+                  onClick={() => navigate(`/sessions/${encodeURIComponent(session.id)}`)}
+                  elevation="outlined"
+                  className="transition-colors hover:border-primary/50"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Badge variant={config.variant} className="gap-1 shrink-0">
+                        {config.icon}
+                        {session.status}
+                      </Badge>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold truncate">{session.project}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {session.flow} &middot; {session.phase}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4 shrink-0">
+                      <div className="w-32 hidden sm:block">
+                        <ProgressBar value={session.progress} showPercentage />
+                      </div>
+                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <Clock className="size-3" />
+                        <time dateTime={session.started_at}>
+                          {new Date(session.started_at).toLocaleDateString()}
+                        </time>
+                      </div>
+                    </div>
+                  </div>
+                  {session.current_agent && (
+                    <p className="text-xs text-muted-foreground mt-2">
+                      Current agent: <span className="font-medium">{session.current_agent}</span>
+                    </p>
+                  )}
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </PageShell>
   );
 }

--- a/src/webapp/ui/src/pages/traceability/traceability-explorer-page.tsx
+++ b/src/webapp/ui/src/pages/traceability/traceability-explorer-page.tsx
@@ -9,8 +9,7 @@ import { Input } from '@/components/ui/input';
 import { DataTable } from '@/components/ui/data-table';
 import { MetricCard } from '@/components/ui/metric-card';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Spinner } from '@/components/ui/spinner';
-import { AlertBanner } from '@/components/ui/alert-banner';
+import { PageShell } from '@/components/ui/page-shell';
 import { Button } from '@/components/ui/button';
 import { Heading, Text } from '@/components/ui/typography';
 import { PageHeader } from '@/components/layout/page-header';
@@ -215,29 +214,6 @@ export default function TraceabilityExplorerPage() {
     return counts;
   }, [entities]);
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Spinner label="Loading traceability data…" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-6">
-        <AlertBanner variant="error">
-          <div className="flex items-center justify-between gap-4 w-full">
-            <span>Failed to load traceability data: {(error as Error).message}</span>
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="size-3 mr-1.5" /> Retry
-            </Button>
-          </div>
-        </AlertBanner>
-      </div>
-    );
-  }
-
   const contextItems: ContextStripItem[] = [
     { id: 'entities', label: 'Entities', value: String(entities.length) },
     {
@@ -255,177 +231,184 @@ export default function TraceabilityExplorerPage() {
   ];
 
   return (
-    <div className="p-6 space-y-6" data-testid="traceability-explorer-page">
-      <PageHeader
-        title="Traceability Explorer"
-        subtitle="Navigate requirement-to-test chains as governed delivery pathways."
-        chips={[
-          { id: 'traceability', label: 'Traceability', tone: 'info' },
-          { id: 'governed', label: 'Governed' },
-        ]}
-      />
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading traceability data…"
+      error={error as Error | null}
+      onRetry={() => refetch()}
+    >
+      <div className="p-6 space-y-6" data-testid="traceability-explorer-page">
+        <PageHeader
+          title="Traceability Explorer"
+          subtitle="Navigate requirement-to-test chains as governed delivery pathways."
+          chips={[
+            { id: 'traceability', label: 'Traceability', tone: 'info' },
+            { id: 'governed', label: 'Governed' },
+          ]}
+        />
 
-      <ContextStrip items={contextItems} />
+        <ContextStrip items={contextItems} />
 
-      <MissionControlHero
-        eyebrow="Traceability explorer"
-        title="Follow requirement-to-test chains as governed delivery pathways"
-        description="Traceability shows whether intent, design, implementation, and tests remain connected. Gaps here are delivery risks, not just missing rows."
-        badges={
-          <>
-            <ControlSignalBadge signal="governed" />
-            {gaps.length > 0 && <ControlSignalBadge signal="needs-human-input" />}
-            <Badge variant="outline">Traceability</Badge>
-          </>
-        }
-        metrics={[
-          {
-            label: 'Entities',
-            value: String(entities.length),
-            detail: 'Tracked traceability nodes',
-          },
-          {
-            label: 'Requirements',
-            value: String(typeCounts.requirement),
-            detail: 'Intent-level inputs',
-          },
-          { label: 'Tests', value: String(typeCounts.test), detail: 'Verification endpoints' },
-          {
-            label: 'Coverage gaps',
-            value: String(gaps.length),
-            detail: 'Broken or incomplete chains',
-          },
-        ]}
-        motifs={
-          <>
-            <StatusMotif
-              kind="governance"
-              title="Traceability is auditable"
-              description="Each entity is visible as part of a governed chain, making delivery lineage inspectable instead of assumed."
+        <MissionControlHero
+          eyebrow="Traceability explorer"
+          title="Follow requirement-to-test chains as governed delivery pathways"
+          description="Traceability shows whether intent, design, implementation, and tests remain connected. Gaps here are delivery risks, not just missing rows."
+          badges={
+            <>
+              <ControlSignalBadge signal="governed" />
+              {gaps.length > 0 && <ControlSignalBadge signal="needs-human-input" />}
+              <Badge variant="outline">Traceability</Badge>
+            </>
+          }
+          metrics={[
+            {
+              label: 'Entities',
+              value: String(entities.length),
+              detail: 'Tracked traceability nodes',
+            },
+            {
+              label: 'Requirements',
+              value: String(typeCounts.requirement),
+              detail: 'Intent-level inputs',
+            },
+            { label: 'Tests', value: String(typeCounts.test), detail: 'Verification endpoints' },
+            {
+              label: 'Coverage gaps',
+              value: String(gaps.length),
+              detail: 'Broken or incomplete chains',
+            },
+          ]}
+          motifs={
+            <>
+              <StatusMotif
+                kind="governance"
+                title="Traceability is auditable"
+                description="Each entity is visible as part of a governed chain, making delivery lineage inspectable instead of assumed."
+              />
+              <StatusMotif
+                kind="agent"
+                title="Execution leaves links behind"
+                description="The explorer exposes how generated outputs connect across requirement, design, code, and test layers."
+              />
+              <StatusMotif
+                kind="human-loop"
+                title="Coverage gaps need review"
+                description="When links are missing, a person can quickly identify where the chain broke and what evidence is absent."
+              />
+            </>
+          }
+          asideTitle="Explorer controls"
+          asideDescription="Use chain overview for structure, coverage gaps for immediate risk, and the entity browser for targeted inspection."
+          asideContent={
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              <RefreshCw className="size-3 mr-1.5" /> Refresh
+            </Button>
+          }
+        />
+
+        {/* Summary */}
+        <section aria-label="Traceability summary">
+          <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
+            <MetricCard
+              label="Requirements"
+              value={typeCounts.requirement}
+              icon={<FileText className="size-4" />}
+              trend="neutral"
             />
-            <StatusMotif
-              kind="agent"
-              title="Execution leaves links behind"
-              description="The explorer exposes how generated outputs connect across requirement, design, code, and test layers."
+            <MetricCard
+              label="Designs"
+              value={typeCounts.design}
+              icon={<Palette className="size-4" />}
+              trend="neutral"
             />
-            <StatusMotif
-              kind="human-loop"
-              title="Coverage gaps need review"
-              description="When links are missing, a person can quickly identify where the chain broke and what evidence is absent."
+            <MetricCard
+              label="Code"
+              value={typeCounts.code}
+              icon={<Code className="size-4" />}
+              trend="neutral"
             />
-          </>
-        }
-        asideTitle="Explorer controls"
-        asideDescription="Use chain overview for structure, coverage gaps for immediate risk, and the entity browser for targeted inspection."
-        asideContent={
-          <Button variant="outline" size="sm" onClick={() => refetch()}>
-            <RefreshCw className="size-3 mr-1.5" /> Refresh
-          </Button>
-        }
-      />
-
-      {/* Summary */}
-      <section aria-label="Traceability summary">
-        <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-          <MetricCard
-            label="Requirements"
-            value={typeCounts.requirement}
-            icon={<FileText className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Designs"
-            value={typeCounts.design}
-            icon={<Palette className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Code"
-            value={typeCounts.code}
-            icon={<Code className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Tests"
-            value={typeCounts.test}
-            icon={<TestTube className="size-4" />}
-            trend="neutral"
-          />
-          <MetricCard
-            label="Coverage Gaps"
-            value={gaps.length}
-            icon={<AlertTriangle className="size-4" />}
-            trend={gaps.length > 0 ? 'down' : 'neutral'}
-          />
-        </div>
-      </section>
-
-      {/* Chain visualization */}
-      <section aria-label="Traceability chain">
-        <Heading level={2} className="mb-3">
-          Chain Overview
-        </Heading>
-        <TraceChainVisual entities={entities} />
-      </section>
-
-      {/* Coverage gaps */}
-      {gaps.length > 0 && (
-        <section aria-label="Coverage gaps">
-          <Heading level={2} className="mb-3">
-            <AlertTriangle className="size-4 inline mr-2 text-amber-500" />
-            Coverage Gaps
-          </Heading>
-          <DataTable columns={gapColumns} data={gaps} enableSorting emptyTitle="No gaps" />
-        </section>
-      )}
-
-      {/* Entity browser with filters */}
-      <section aria-label="Entity browser">
-        <Heading level={2} className="mb-3">
-          All Entities
-        </Heading>
-        <Card elevation="flat" className="mb-3 p-4 bg-card/78">
-          <div className="flex items-center gap-3 flex-wrap">
-            <Search className="size-4 text-muted-foreground" />
-            <Input
-              placeholder="Search entities…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="h-9 max-w-sm"
-              aria-label="Search entities"
+            <MetricCard
+              label="Tests"
+              value={typeCounts.test}
+              icon={<TestTube className="size-4" />}
+              trend="neutral"
             />
-            <select
-              className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
-              value={filterType}
-              onChange={(e) => setFilterType(e.target.value as TraceEntityType | '')}
-              aria-label="Filter by entity type"
-            >
-              <option value="">All Types</option>
-              {chainOrder.map((t) => (
-                <option key={t} value={t}>
-                  {entityConfig[t].label}
-                </option>
-              ))}
-            </select>
+            <MetricCard
+              label="Coverage Gaps"
+              value={gaps.length}
+              icon={<AlertTriangle className="size-4" />}
+              trend={gaps.length > 0 ? 'down' : 'neutral'}
+            />
           </div>
-        </Card>
+        </section>
 
-        {filtered.length === 0 ? (
-          <EmptyState
-            icon={<GitPullRequest className="size-12" />}
-            title="No entities found"
-            description="Traceability entities will appear once artifacts are registered."
-          />
-        ) : (
-          <DataTable
-            columns={entityColumns}
-            data={filtered}
-            enableSorting
-            enablePagination
-            emptyTitle="No matching entities"
-          />
+        {/* Chain visualization */}
+        <section aria-label="Traceability chain">
+          <Heading level={2} className="mb-3">
+            Chain Overview
+          </Heading>
+          <TraceChainVisual entities={entities} />
+        </section>
+
+        {/* Coverage gaps */}
+        {gaps.length > 0 && (
+          <section aria-label="Coverage gaps">
+            <Heading level={2} className="mb-3">
+              <AlertTriangle className="size-4 inline mr-2 text-amber-500" />
+              Coverage Gaps
+            </Heading>
+            <DataTable columns={gapColumns} data={gaps} enableSorting emptyTitle="No gaps" />
+          </section>
         )}
-      </section>
-    </div>
+
+        {/* Entity browser with filters */}
+        <section aria-label="Entity browser">
+          <Heading level={2} className="mb-3">
+            All Entities
+          </Heading>
+          <Card elevation="flat" className="mb-3 p-4 bg-card/78">
+            <div className="flex items-center gap-3 flex-wrap">
+              <Search className="size-4 text-muted-foreground" />
+              <Input
+                placeholder="Search entities…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-9 max-w-sm"
+                aria-label="Search entities"
+              />
+              <select
+                className="h-9 rounded-xl border border-border/70 bg-background/80 px-3 text-sm shadow-sm"
+                value={filterType}
+                onChange={(e) => setFilterType(e.target.value as TraceEntityType | '')}
+                aria-label="Filter by entity type"
+              >
+                <option value="">All Types</option>
+                {chainOrder.map((t) => (
+                  <option key={t} value={t}>
+                    {entityConfig[t].label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </Card>
+
+          {filtered.length === 0 ? (
+            <EmptyState
+              icon={<GitPullRequest className="size-12" />}
+              title="No entities found"
+              description="Traceability entities will appear once artifacts are registered."
+            />
+          ) : (
+            <DataTable
+              columns={entityColumns}
+              data={filtered}
+              enableSorting
+              enablePagination
+              emptyTitle="No matching entities"
+            />
+          )}
+        </section>
+      </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
## Summary\n- implement operational card and queue/triage primitives with Storybook coverage (UI-010)\n- standardize loading/error/empty/no-access page states via PageShell adoption (UI-018)\n- add audit/evidence aggregation contracts, sample payloads, and hook adapters (UI-025)\n- add observability telemetry contracts, sample payloads, and hook adapters (UI-026)\n- wire observability, governance, sessions, artifact, traceability, and overview pages to new primitives/contracts\n\n## Validation\n- npm run format\n- npm run lint\n- npm run test:coverage\n\n## Notes\n- left unrelated working-tree files uncommitted (run history/docs indexes/load traces)