### PR TITLE
feat(ui): implement UI Redesign Phase 5 domains

### DIFF
--- a/src/webapp/ui/src/App.tsx
+++ b/src/webapp/ui/src/App.tsx
@@ -14,6 +14,7 @@ const OverviewPage = lazy(() => import('@/pages/overview/overview-page'));
 const DashboardPage = lazy(() => import('@/pages/dashboard/dashboard-page'));
 const CommandsPage = lazy(() => import('@/pages/commands/commands-page'));
 const PipelinePage = lazy(() => import('@/pages/pipeline/pipeline-page'));
+const WorkspacesPage = lazy(() => import('@/pages/workspaces/workspaces-page'));
 const SessionsPage = lazy(() => import('@/pages/sessions/sessions-page'));
 const SessionDetailPage = lazy(() => import('@/pages/sessions/session-detail-page'));
 const AgentsPage = lazy(() => import('@/pages/agents/agents-page'));
@@ -25,6 +26,8 @@ const LineagePage = lazy(() => import('@/pages/artifacts/lineage-page'));
 const ObservabilityPage = lazy(() => import('@/pages/observability/observability-page'));
 const GovernanceDashboardPage = lazy(() => import('@/pages/governance/governance-dashboard-page'));
 const ApprovalCenterPage = lazy(() => import('@/pages/approvals/approval-center-page'));
+const PromptsContractsPage = lazy(() => import('@/pages/prompts/prompts-contracts-page'));
+const AdministrationPage = lazy(() => import('@/pages/administration/administration-page'));
 const CockpitDashboardPage = lazy(() => import('@/pages/cockpit/cockpit-dashboard-page'));
 const ExecutionHistoryPage = lazy(() => import('@/pages/agents/execution-history-page'));
 const ApprovalDetailPage = lazy(() => import('@/pages/cockpit/approval-detail-page'));
@@ -58,6 +61,7 @@ const router = createBrowserRouter([
       /* Runtime */
       { index: true, element: overviewElement },
       { path: 'dashboard', element: <DashboardPage /> },
+      { path: 'workspaces', element: <WorkspacesPage /> },
       { path: 'sessions', element: runsElement },
       { path: 'sessions/:id', element: <SessionDetailPage /> },
       { path: 'pipeline', element: <PipelinePage /> },
@@ -76,6 +80,7 @@ const router = createBrowserRouter([
       { path: 'artifacts/lineage', element: <LineagePage /> },
       { path: 'audit', element: <AuditEvidenceExplorerPage /> },
       { path: 'questionnaires', element: <QuestionnairesPage /> },
+      { path: 'prompts-contracts', element: <PromptsContractsPage /> },
 
       /* Observability */
       { path: 'observability', element: observabilityElement },
@@ -94,6 +99,14 @@ const router = createBrowserRouter([
 
       /* Cockpit — M27 */
       { path: 'cockpit', element: <CockpitDashboardPage /> },
+      {
+        path: 'administration',
+        element: (
+          <AccessGuard requiredRole="admin">
+            <AdministrationPage />
+          </AccessGuard>
+        ),
+      },
       {
         path: 'cockpit/approvals/:id',
         element: (

--- a/src/webapp/ui/src/components/layout/app-layout.tsx
+++ b/src/webapp/ui/src/components/layout/app-layout.tsx
@@ -32,6 +32,9 @@ import {
   Bot,
   Gauge,
   History,
+  FolderKanban,
+  FileCode2,
+  Settings2,
 } from 'lucide-react';
 
 const iconMap: Record<string, React.ReactNode> = {
@@ -47,6 +50,9 @@ const iconMap: Record<string, React.ReactNode> = {
   Bot: <Bot className="size-4" />,
   Gauge: <Gauge className="size-4" />,
   History: <History className="size-4" />,
+  FolderKanban: <FolderKanban className="size-4" />,
+  FileCode2: <FileCode2 className="size-4" />,
+  Settings2: <Settings2 className="size-4" />,
 };
 
 function toSectionId(section: DomainSection): string {

--- a/src/webapp/ui/src/hooks/index.ts
+++ b/src/webapp/ui/src/hooks/index.ts
@@ -126,3 +126,12 @@ export {
   useApproveWithComment,
   useRejectWithComment,
 } from './use-cockpit';
+
+/* Workspaces (UI-014) */
+export { useWorkspaces, useWorkspaceDetail } from './use-workspaces';
+
+/* Prompts & Contracts (UI-015) */
+export { usePromptContractAssets } from './use-prompt-contracts';
+
+/* Administration (UI-016) */
+export { useAdminUsers, useAdministrationOverview } from './use-administration';

--- a/src/webapp/ui/src/hooks/use-administration.ts
+++ b/src/webapp/ui/src/hooks/use-administration.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/lib/api-client';
+import { queryKeys } from '@/lib/query-keys';
+import type {
+  AdminUsersResponse,
+  AdministrationOverviewResponse,
+  PolicySignalsResponse,
+  TimestampedResponse,
+  DashboardHealth,
+} from '@/lib/api-types';
+
+/** Fetch user directory for administration/RBAC management views. */
+export function useAdminUsers() {
+  return useQuery({
+    queryKey: queryKeys.administration.users,
+    queryFn: () => apiGet<AdminUsersResponse>('/admin/users'),
+  });
+}
+
+/** Build a compact integrations + RBAC overview from existing APIs. */
+export function useAdministrationOverview() {
+  return useQuery({
+    queryKey: queryKeys.administration.integrations,
+    queryFn: async (): Promise<AdministrationOverviewResponse> => {
+      const [usersRes, signalsRes, healthRes] = await Promise.all([
+        apiGet<AdminUsersResponse>('/admin/users'),
+        apiGet<PolicySignalsResponse>('/v1/policies/signals'),
+        apiGet<TimestampedResponse<DashboardHealth>>('/dashboard/health'),
+      ]);
+
+      const role_counts = {
+        admin: usersRes.users.filter((user) => user.role === 'admin').length,
+        operator: usersRes.users.filter((user) => user.role === 'operator').length,
+        viewer: usersRes.users.filter((user) => user.role === 'viewer').length,
+      };
+
+      const checks = signalsRes.checks ?? {};
+      const failedChecks = Object.entries(checks).filter(([, passed]) => !passed).length;
+
+      const integrations = [
+        {
+          id: 'policy-signals',
+          label: 'Policy signal pipeline',
+          status: (failedChecks === 0 ? 'healthy' : failedChecks < 3 ? 'degraded' : 'offline') as
+            | 'healthy'
+            | 'degraded'
+            | 'offline',
+          detail: `${Object.keys(checks).length} checks, ${failedChecks} failing`,
+        },
+        {
+          id: 'quality-health',
+          label: 'Quality telemetry',
+          status: (healthRes.data.quality.status === 'ok'
+            ? 'healthy'
+            : healthRes.data.quality.status === 'warning'
+              ? 'degraded'
+              : 'offline') as 'healthy' | 'degraded' | 'offline',
+          detail: String(healthRes.data.quality.details ?? healthRes.data.quality.label),
+        },
+        {
+          id: 'deployment-health',
+          label: 'Deployment telemetry',
+          status: (healthRes.data.deployment.status === 'ok'
+            ? 'healthy'
+            : healthRes.data.deployment.status === 'warning'
+              ? 'degraded'
+              : 'offline') as 'healthy' | 'degraded' | 'offline',
+          detail: String(healthRes.data.deployment.details ?? healthRes.data.deployment.label),
+        },
+      ];
+
+      return {
+        ok: true,
+        role_counts,
+        integrations,
+      };
+    },
+    staleTime: 20_000,
+  });
+}

--- a/src/webapp/ui/src/hooks/use-prompt-contracts.ts
+++ b/src/webapp/ui/src/hooks/use-prompt-contracts.ts
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/lib/api-client';
+import { queryKeys } from '@/lib/query-keys';
+import type {
+  PromptContractAssetsResponse,
+  PromptContractAsset,
+  QuestionnairesResponse,
+  DecisionsResponse,
+  PolicyListResponse,
+} from '@/lib/api-types';
+
+/** Aggregate prompt and contract assets from existing governance endpoints. */
+export function usePromptContractAssets() {
+  return useQuery({
+    queryKey: queryKeys.promptsContracts.assets,
+    queryFn: async (): Promise<PromptContractAssetsResponse> => {
+      const [questionnaires, decisions, policies] = await Promise.all([
+        apiGet<QuestionnairesResponse>('/questionnaires'),
+        apiGet<DecisionsResponse>('/decisions'),
+        apiGet<PolicyListResponse>('/v1/policies'),
+      ]);
+
+      const questionnaireAssets: PromptContractAsset[] = questionnaires.questionnaires.map((q) => {
+        const openCount = q.questions.filter((question) => question.status !== 'ANSWERED').length;
+        return {
+          id: q.file,
+          type: 'questionnaire',
+          title: q.agent || q.file,
+          scope: q.phase || 'unknown',
+          governance_status:
+            openCount === 0 ? 'compliant' : openCount <= 3 ? 'review' : 'attention',
+          updated_at: q.generated,
+        };
+      });
+
+      const decisionAssets: PromptContractAsset[] = decisions.open.map((d) => ({
+        id: d.id,
+        type: 'decision',
+        title: d.question,
+        scope: d.scope,
+        governance_status: d.priority === 'HIGH' ? 'attention' : 'review',
+        updated_at: d.date,
+      }));
+
+      const policyAssets: PromptContractAsset[] = policies.policies.map((policy) => ({
+        id: policy.id,
+        type: 'policy',
+        title: policy.name,
+        scope: policy.scope,
+        governance_status: policy.severity === 'blocking' ? 'attention' : 'compliant',
+      }));
+
+      const assets = [...questionnaireAssets, ...decisionAssets, ...policyAssets];
+      const compliant_assets = assets.filter(
+        (asset) => asset.governance_status === 'compliant'
+      ).length;
+      const review_assets = assets.filter((asset) => asset.governance_status === 'review').length;
+      const attention_assets = assets.filter(
+        (asset) => asset.governance_status === 'attention'
+      ).length;
+
+      return {
+        ok: true,
+        generated_at: new Date().toISOString(),
+        assets,
+        summary: {
+          total_assets: assets.length,
+          compliant_assets,
+          review_assets,
+          attention_assets,
+        },
+      };
+    },
+    staleTime: 30_000,
+  });
+}

--- a/src/webapp/ui/src/hooks/use-workspaces.ts
+++ b/src/webapp/ui/src/hooks/use-workspaces.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/lib/api-client';
+import { queryKeys } from '@/lib/query-keys';
+import type { WorkspacesListResponse, WorkspaceDetailResponse } from '@/lib/api-types';
+
+/** List all registered workspaces. */
+export function useWorkspaces() {
+  return useQuery({
+    queryKey: queryKeys.workspaces.all,
+    queryFn: () => apiGet<WorkspacesListResponse>('/workspaces'),
+  });
+}
+
+/** Fetch workspace details and projects by workspace id. */
+export function useWorkspaceDetail(workspaceId: string | null) {
+  return useQuery({
+    queryKey: workspaceId
+      ? queryKeys.workspaces.detail(workspaceId)
+      : queryKeys.workspaces.detail('_'),
+    queryFn: () =>
+      apiGet<WorkspaceDetailResponse>(`/workspaces/${encodeURIComponent(workspaceId ?? '')}`),
+    enabled: Boolean(workspaceId),
+  });
+}

--- a/src/webapp/ui/src/lib/api-types.ts
+++ b/src/webapp/ui/src/lib/api-types.ts
@@ -1119,6 +1119,109 @@ export interface ProvenanceQueryParams {
   page_size?: number;
 }
 
+/* ──────────────────────────────────────────────
+ * Workspaces (UI-014)
+ * ────────────────────────────────────────────── */
+
+export type WorkspaceRepositoryProvider = 'github' | 'azure-devops' | 'gitlab' | 'local';
+
+export interface WorkspaceRepository {
+  id: string;
+  name: string;
+  provider: WorkspaceRepositoryProvider;
+  url: string;
+  defaultBranch: string;
+  tags?: string[];
+}
+
+export interface WorkspaceSummary {
+  id: string;
+  name: string;
+  repositories: WorkspaceRepository[];
+  owner: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkspaceProject {
+  id: string;
+  workspaceId: string;
+  name: string;
+  repositories: string[];
+  sessions: string[];
+  status: 'active' | 'archived' | 'draft';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkspacesListResponse extends OkResponse {
+  count: number;
+  workspaces: WorkspaceSummary[];
+}
+
+export interface WorkspaceDetailResponse extends OkResponse {
+  workspace: WorkspaceSummary;
+  projects: WorkspaceProject[];
+}
+
+/* ──────────────────────────────────────────────
+ * Prompts & Contracts (UI-015)
+ * ────────────────────────────────────────────── */
+
+export interface PromptContractAsset {
+  id: string;
+  type: 'questionnaire' | 'decision' | 'policy';
+  title: string;
+  scope: string;
+  governance_status: 'compliant' | 'review' | 'attention';
+  updated_at?: string;
+}
+
+export interface PromptContractAssetsResponse extends OkResponse {
+  generated_at: string;
+  assets: PromptContractAsset[];
+  summary: {
+    total_assets: number;
+    compliant_assets: number;
+    review_assets: number;
+    attention_assets: number;
+  };
+}
+
+/* ──────────────────────────────────────────────
+ * Administration / RBAC / Integrations (UI-016)
+ * ────────────────────────────────────────────── */
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  name?: string;
+  avatar_url?: string;
+  role: 'admin' | 'operator' | 'viewer';
+  created_at?: string;
+  last_login?: string;
+}
+
+export interface AdminUsersResponse {
+  users: AdminUser[];
+}
+
+export interface AdministrationIntegrationStatus {
+  id: string;
+  label: string;
+  status: 'healthy' | 'degraded' | 'offline';
+  detail: string;
+}
+
+export interface AdministrationOverviewResponse extends OkResponse {
+  integrations: AdministrationIntegrationStatus[];
+  role_counts: {
+    admin: number;
+    operator: number;
+    viewer: number;
+  };
+}
+
 export interface ProvenanceResponse extends OkResponse {
   count: number;
   total?: number;

--- a/src/webapp/ui/src/lib/query-keys.ts
+++ b/src/webapp/ui/src/lib/query-keys.ts
@@ -88,6 +88,23 @@ export const queryKeys = {
     policyEvaluation: ['governance', 'policy-evaluation'] as const,
   },
 
+  /* Workspaces (UI-014) */
+  workspaces: {
+    all: ['workspaces'] as const,
+    detail: (id: string) => ['workspaces', id] as const,
+  },
+
+  /* Prompts & Contracts (UI-015) */
+  promptsContracts: {
+    assets: ['prompts-contracts', 'assets'] as const,
+  },
+
+  /* Administration (UI-016) */
+  administration: {
+    users: ['administration', 'users'] as const,
+    integrations: ['administration', 'integrations'] as const,
+  },
+
   /* Traceability (M10) */
   traceability: {
     chains: ['traceability', 'chains'] as const,

--- a/src/webapp/ui/src/lib/routes.ts
+++ b/src/webapp/ui/src/lib/routes.ts
@@ -29,6 +29,14 @@ export const routes = {
   /* Overview */
   dashboard: { path: '/', label: 'Overview', icon: 'LayoutDashboard', section: 'Overview' },
 
+  /* Workspaces */
+  workspaces: {
+    path: '/workspaces',
+    label: 'Workspaces',
+    icon: 'FolderKanban',
+    section: 'Workspaces',
+  },
+
   /* Runs */
   sessions: { path: '/sessions', label: 'Runs', icon: 'Activity', section: 'Runs' },
   pipeline: { path: '/pipeline', label: 'Pipeline', icon: 'GitBranch', section: 'Runs' },
@@ -67,6 +75,12 @@ export const routes = {
     icon: 'ClipboardList',
     section: 'Prompts & Contracts',
   },
+  promptsContracts: {
+    path: '/prompts-contracts',
+    label: 'Prompt & Contract Registry',
+    icon: 'FileCode2',
+    section: 'Prompts & Contracts',
+  },
 
   /* Audit & Evidence */
   audit: {
@@ -94,6 +108,14 @@ export const routes = {
     label: 'Cockpit',
     icon: 'Gauge',
     section: 'Observability',
+  },
+
+  /* Administration */
+  administration: {
+    path: '/administration',
+    label: 'Administration',
+    icon: 'Settings2',
+    section: 'Administration',
   },
 } as const satisfies Record<string, RouteEntry>;
 

--- a/src/webapp/ui/src/pages/administration/administration-page.tsx
+++ b/src/webapp/ui/src/pages/administration/administration-page.tsx
@@ -1,0 +1,163 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { PageShell } from '@/components/ui/page-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
+import { useAdministrationOverview, useAdminUsers, useAuthorization } from '@/hooks';
+import type { AdminUser, AdministrationIntegrationStatus } from '@/lib/api-types';
+import { KeyRound, Settings2, Users } from 'lucide-react';
+
+const statusVariant = {
+  healthy: 'success',
+  degraded: 'warning',
+  offline: 'error',
+} as const;
+
+export default function AdministrationPage() {
+  const { user } = useAuthorization();
+  const usersQuery = useAdminUsers();
+  const overviewQuery = useAdministrationOverview();
+
+  const isLoading = usersQuery.isLoading || overviewQuery.isLoading;
+  const combinedError = (usersQuery.error ?? overviewQuery.error) as Error | null;
+
+  const roleCounts = overviewQuery.data?.role_counts ?? { admin: 0, operator: 0, viewer: 0 };
+  const integrations = overviewQuery.data?.integrations ?? [];
+  const users = usersQuery.data?.users ?? [];
+
+  const contextItems = useMemo<ContextStripItem[]>(
+    () => [
+      {
+        id: 'admin-actors',
+        label: 'Users',
+        value: String(users.length),
+        tone: users.length > 0 ? 'info' : 'neutral',
+      },
+      {
+        id: 'admin-admins',
+        label: 'Admins',
+        value: String(roleCounts.admin),
+        tone: roleCounts.admin > 0 ? 'success' : 'warning',
+      },
+      {
+        id: 'admin-integrations',
+        label: 'Integrations',
+        value: String(integrations.length),
+        tone: integrations.length > 0 ? 'info' : 'neutral',
+      },
+      {
+        id: 'admin-role',
+        label: 'Current role',
+        value: user?.role ?? 'unknown',
+        tone: user?.role === 'admin' ? 'success' : 'warning',
+      },
+    ],
+    [integrations.length, roleCounts.admin, user?.role, users.length]
+  );
+
+  return (
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading administration data..."
+      error={combinedError}
+      onRetry={() => {
+        void usersQuery.refetch();
+        void overviewQuery.refetch();
+      }}
+      isEmpty={!isLoading && users.length === 0 && integrations.length === 0}
+      emptyState={{
+        icon: <Settings2 className="size-8" />,
+        title: 'No administration data available',
+        description: 'This view requires admin APIs and policy telemetry to be available.',
+      }}
+    >
+      <div className="space-y-6 p-6" data-testid="administration-page">
+        <PageHeader
+          title="Administration"
+          subtitle="Manage RBAC visibility and integration health for platform governance."
+          chips={[
+            {
+              id: 'administration-chip-role',
+              label: `Role: ${user?.role ?? 'unknown'}`,
+              tone: user?.role === 'admin' ? 'success' : 'warning',
+            },
+            {
+              id: 'administration-chip-users',
+              label: `${users.length} users`,
+              tone: 'info',
+            },
+          ]}
+        />
+
+        <ContextStrip items={contextItems} />
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          <Card elevation="flat" className="space-y-3 p-4">
+            <div className="flex items-center gap-2">
+              <Users className="size-4 text-info" />
+              <h2 className="text-sm font-semibold">Role directory</h2>
+            </div>
+
+            {users.length === 0 ? (
+              <EmptyState title="No users" description="No user directory entries were returned." />
+            ) : (
+              <div className="space-y-2">
+                {users.map((entry: AdminUser) => (
+                  <div key={entry.id} className="rounded-lg border border-border/70 p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-medium">{entry.name || entry.email}</p>
+                        <p className="text-xs text-muted-foreground">{entry.email}</p>
+                      </div>
+                      <Badge
+                        variant={
+                          entry.role === 'admin'
+                            ? 'success'
+                            : entry.role === 'operator'
+                              ? 'info'
+                              : 'outline'
+                        }
+                      >
+                        {entry.role}
+                      </Badge>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+
+          <Card elevation="flat" className="space-y-3 p-4">
+            <div className="flex items-center gap-2">
+              <KeyRound className="size-4 text-info" />
+              <h2 className="text-sm font-semibold">Integration health</h2>
+            </div>
+
+            {integrations.length === 0 ? (
+              <EmptyState
+                title="No integration signals"
+                description="No integration status records were returned by administration APIs."
+              />
+            ) : (
+              <div className="space-y-2">
+                {integrations.map((integration: AdministrationIntegrationStatus) => (
+                  <div key={integration.id} className="rounded-lg border border-border/70 p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium">{integration.label}</p>
+                      <Badge variant={statusVariant[integration.status]}>
+                        {integration.status}
+                      </Badge>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{integration.detail}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/webapp/ui/src/pages/prompts/prompts-contracts-page.tsx
+++ b/src/webapp/ui/src/pages/prompts/prompts-contracts-page.tsx
@@ -1,0 +1,186 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { PageShell } from '@/components/ui/page-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
+import { usePromptContractAssets } from '@/hooks';
+import type { PromptContractAsset } from '@/lib/api-types';
+import { ClipboardList, FileCode2, Scale } from 'lucide-react';
+
+const typeIcon = {
+  questionnaire: <ClipboardList className="size-4 text-info" />,
+  decision: <Scale className="size-4 text-warning" />,
+  policy: <FileCode2 className="size-4 text-success" />,
+};
+
+const governanceVariant = {
+  compliant: 'success',
+  review: 'warning',
+  attention: 'error',
+} as const;
+
+export default function PromptsContractsPage() {
+  const { data, isLoading, error, refetch } = usePromptContractAssets();
+
+  const grouped = useMemo(() => {
+    const assets: PromptContractAsset[] = data?.assets ?? [];
+    return {
+      questionnaires: assets.filter((asset: PromptContractAsset) => asset.type === 'questionnaire'),
+      decisions: assets.filter((asset: PromptContractAsset) => asset.type === 'decision'),
+      policies: assets.filter((asset: PromptContractAsset) => asset.type === 'policy'),
+    };
+  }, [data?.assets]);
+
+  const contextItems = useMemo<ContextStripItem[]>(
+    () => [
+      {
+        id: 'prompts-total',
+        label: 'Total assets',
+        value: String(data?.summary.total_assets ?? 0),
+        tone: (data?.summary.total_assets ?? 0) > 0 ? 'info' : 'neutral',
+      },
+      {
+        id: 'prompts-compliant',
+        label: 'Compliant',
+        value: String(data?.summary.compliant_assets ?? 0),
+        tone: 'success',
+      },
+      {
+        id: 'prompts-review',
+        label: 'Review',
+        value: String(data?.summary.review_assets ?? 0),
+        tone: (data?.summary.review_assets ?? 0) > 0 ? 'warning' : 'neutral',
+      },
+      {
+        id: 'prompts-attention',
+        label: 'Attention',
+        value: String(data?.summary.attention_assets ?? 0),
+        tone: (data?.summary.attention_assets ?? 0) > 0 ? 'critical' : 'success',
+      },
+    ],
+    [
+      data?.summary.attention_assets,
+      data?.summary.compliant_assets,
+      data?.summary.review_assets,
+      data?.summary.total_assets,
+    ]
+  );
+
+  return (
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading prompt and contract assets..."
+      error={error as Error | null}
+      onRetry={() => refetch()}
+      isEmpty={(data?.assets.length ?? 0) === 0}
+      emptyState={{
+        icon: <FileCode2 className="size-8" />,
+        title: 'No prompt or contract assets found',
+        description:
+          'Assets appear once questionnaires, decisions, or governance policies are available.',
+      }}
+    >
+      <div className="space-y-6 p-6" data-testid="prompts-contracts-page">
+        <PageHeader
+          title="Prompts & Contracts"
+          subtitle="Review prompt assets and governance contracts with explicit compliance status across domains."
+          chips={[
+            {
+              id: 'prompts-chip-updated',
+              label: data?.generated_at
+                ? new Date(data.generated_at).toLocaleString()
+                : 'No timestamp',
+              tone: 'info',
+            },
+            {
+              id: 'prompts-chip-count',
+              label: `${data?.summary.total_assets ?? 0} assets`,
+              tone: 'default',
+            },
+          ]}
+        />
+
+        <ContextStrip items={contextItems} />
+
+        <div className="grid gap-4 xl:grid-cols-3">
+          <Card elevation="flat" className="space-y-3 p-4">
+            <h2 className="text-sm font-semibold">Questionnaire assets</h2>
+            {grouped.questionnaires.length === 0 ? (
+              <EmptyState
+                title="No questionnaires"
+                description="No questionnaire contracts were discovered."
+              />
+            ) : (
+              grouped.questionnaires.map((asset: PromptContractAsset) => (
+                <div key={asset.id} className="rounded-lg border border-border/70 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      {typeIcon[asset.type]}
+                      <p className="text-sm font-medium">{asset.title}</p>
+                    </div>
+                    <Badge variant={governanceVariant[asset.governance_status]}>
+                      {asset.governance_status}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">Scope: {asset.scope}</p>
+                </div>
+              ))
+            )}
+          </Card>
+
+          <Card elevation="flat" className="space-y-3 p-4">
+            <h2 className="text-sm font-semibold">Decision contracts</h2>
+            {grouped.decisions.length === 0 ? (
+              <EmptyState
+                title="No open decisions"
+                description="No decision contracts require active review."
+              />
+            ) : (
+              grouped.decisions.map((asset: PromptContractAsset) => (
+                <div key={asset.id} className="rounded-lg border border-border/70 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      {typeIcon[asset.type]}
+                      <p className="text-sm font-medium">{asset.title}</p>
+                    </div>
+                    <Badge variant={governanceVariant[asset.governance_status]}>
+                      {asset.governance_status}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">Scope: {asset.scope}</p>
+                </div>
+              ))
+            )}
+          </Card>
+
+          <Card elevation="flat" className="space-y-3 p-4">
+            <h2 className="text-sm font-semibold">Policy contracts</h2>
+            {grouped.policies.length === 0 ? (
+              <EmptyState
+                title="No policies"
+                description="No policy contracts were returned by governance endpoints."
+              />
+            ) : (
+              grouped.policies.map((asset: PromptContractAsset) => (
+                <div key={asset.id} className="rounded-lg border border-border/70 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      {typeIcon[asset.type]}
+                      <p className="text-sm font-medium">{asset.title}</p>
+                    </div>
+                    <Badge variant={governanceVariant[asset.governance_status]}>
+                      {asset.governance_status}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">Scope: {asset.scope}</p>
+                </div>
+              ))
+            )}
+          </Card>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/src/webapp/ui/src/pages/workspaces/workspaces-page.tsx
+++ b/src/webapp/ui/src/pages/workspaces/workspaces-page.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { PageShell } from '@/components/ui/page-shell';
+import { PageHeader } from '@/components/layout/page-header';
+import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
+import { useWorkspaceDetail, useWorkspaces } from '@/hooks';
+import { FolderKanban, GitFork, Layers, RefreshCw } from 'lucide-react';
+
+export default function WorkspacesPage() {
+  const { data, isLoading, error, refetch } = useWorkspaces();
+  const workspaces = useMemo(() => data?.workspaces ?? [], [data?.workspaces]);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId && workspaces.length > 0) {
+      setSelectedWorkspaceId(workspaces[0].id);
+    }
+  }, [selectedWorkspaceId, workspaces]);
+
+  const selectedWorkspace =
+    workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? workspaces[0] ?? null;
+
+  const {
+    data: detail,
+    isLoading: detailLoading,
+    error: detailError,
+    refetch: refetchDetail,
+  } = useWorkspaceDetail(selectedWorkspace?.id ?? null);
+
+  const contextItems = useMemo<ContextStripItem[]>(() => {
+    const repositoryCount = workspaces.reduce(
+      (sum, workspace) => sum + workspace.repositories.length,
+      0
+    );
+
+    return [
+      {
+        id: 'workspaces-count',
+        label: 'Workspaces',
+        value: String(workspaces.length),
+        tone: workspaces.length > 0 ? 'info' : 'neutral',
+      },
+      {
+        id: 'workspaces-repositories',
+        label: 'Repositories',
+        value: String(repositoryCount),
+        tone: repositoryCount > 0 ? 'success' : 'neutral',
+      },
+      {
+        id: 'workspaces-projects',
+        label: 'Projects',
+        value: String(detail?.projects.length ?? 0),
+        tone: (detail?.projects.length ?? 0) > 0 ? 'info' : 'neutral',
+      },
+      {
+        id: 'workspaces-selected',
+        label: 'Selected',
+        value: selectedWorkspace?.name ?? 'None',
+        tone: selectedWorkspace ? 'success' : 'neutral',
+      },
+    ];
+  }, [detail?.projects.length, selectedWorkspace, workspaces]);
+
+  return (
+    <PageShell
+      isLoading={isLoading}
+      loadingLabel="Loading workspaces..."
+      error={error as Error | null}
+      onRetry={() => refetch()}
+      isEmpty={workspaces.length === 0}
+      emptyState={{
+        icon: <FolderKanban className="size-8" />,
+        title: 'No workspaces found',
+        description: 'Create a workspace to start grouping repositories and projects.',
+      }}
+    >
+      <div className="space-y-6 p-6" data-testid="workspaces-page">
+        <PageHeader
+          title="Workspaces"
+          subtitle="Manage workspace-level context, repositories, and projects for orchestration runs."
+          chips={[
+            {
+              id: 'workspaces-chip-total',
+              label: `${workspaces.length} total`,
+              tone: workspaces.length > 0 ? 'info' : 'default',
+            },
+            {
+              id: 'workspaces-chip-selection',
+              label: selectedWorkspace?.id ?? 'No selection',
+              tone: selectedWorkspace ? 'success' : 'default',
+            },
+          ]}
+          actions={
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              <RefreshCw className="mr-1.5 size-3" />
+              Refresh
+            </Button>
+          }
+        />
+
+        <ContextStrip items={contextItems} />
+
+        <div className="grid gap-4 lg:grid-cols-[300px_1fr]">
+          <Card elevation="flat" className="space-y-2 p-3">
+            {workspaces.map((workspace) => (
+              <button
+                key={workspace.id}
+                type="button"
+                onClick={() => setSelectedWorkspaceId(workspace.id)}
+                className={`w-full rounded-xl border px-3 py-2 text-left transition ${
+                  workspace.id === selectedWorkspace?.id
+                    ? 'border-info/40 bg-info/10'
+                    : 'border-border/70 bg-background hover:bg-card'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold">{workspace.name}</p>
+                    <p className="text-xs text-muted-foreground">{workspace.owner}</p>
+                  </div>
+                  <Badge variant="outline">{workspace.repositories.length} repos</Badge>
+                </div>
+              </button>
+            ))}
+          </Card>
+
+          <PageShell
+            isLoading={detailLoading}
+            loadingLabel="Loading workspace detail..."
+            error={detailError as Error | null}
+            onRetry={() => refetchDetail()}
+            isEmpty={!detail || !detail.workspace}
+            emptyState={{
+              icon: <Layers className="size-8" />,
+              title: 'Select a workspace',
+              description: 'Choose a workspace from the left panel to inspect details.',
+            }}
+          >
+            {detail && (
+              <div className="space-y-4">
+                <Card elevation="flat" className="p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <h2 className="text-lg font-semibold">{detail.workspace.name}</h2>
+                      <p className="text-sm text-muted-foreground">
+                        Owned by {detail.workspace.owner}
+                      </p>
+                    </div>
+                    <Badge variant="info">{detail.projects.length} projects</Badge>
+                  </div>
+                </Card>
+
+                <div className="grid gap-4 xl:grid-cols-2">
+                  <Card elevation="flat" className="space-y-3 p-4">
+                    <div className="flex items-center gap-2">
+                      <GitFork className="size-4 text-info" />
+                      <h3 className="text-sm font-semibold">Repositories</h3>
+                    </div>
+                    {detail.workspace.repositories.length === 0 ? (
+                      <EmptyState
+                        title="No repositories"
+                        description="This workspace has no linked repositories yet."
+                      />
+                    ) : (
+                      <div className="space-y-2">
+                        {detail.workspace.repositories.map((repo) => (
+                          <div key={repo.id} className="rounded-lg border border-border/70 p-3">
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="text-sm font-medium">{repo.name}</p>
+                              <Badge variant="neutral">{repo.provider}</Badge>
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">{repo.url}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </Card>
+
+                  <Card elevation="flat" className="space-y-3 p-4">
+                    <div className="flex items-center gap-2">
+                      <Layers className="size-4 text-info" />
+                      <h3 className="text-sm font-semibold">Projects</h3>
+                    </div>
+                    {detail.projects.length === 0 ? (
+                      <EmptyState
+                        title="No projects"
+                        description="Projects can be created from the workspace management APIs."
+                      />
+                    ) : (
+                      <div className="space-y-2">
+                        {detail.projects.map((project) => (
+                          <div key={project.id} className="rounded-lg border border-border/70 p-3">
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="text-sm font-medium">{project.name}</p>
+                              <Badge variant={project.status === 'active' ? 'success' : 'outline'}>
+                                {project.status}
+                              </Badge>
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {project.repositories.length} linked repositories
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </Card>
+                </div>
+              </div>
+            )}
+          </PageShell>
+        </div>
+      </div>
+    </PageShell>
+  );
+}


### PR DESCRIPTION
## Summary\n- Implement UI-014 Workspaces domain with route, navigation, hooks, and page surfaces\n- Implement UI-015 Prompts & Contracts domain with route, navigation, aggregation hook, and governance-focused page\n- Implement UI-016 Administration/RBAC/Integrations domain with admin-gated route, hooks, and page\n- Add shared plumbing updates for new domains (query keys, API types, icon mapping, hooks barrel exports)\n\n## Validation\n- npm run format\n- npm run lint\n- npm run test:coverage\n- npm run build\n\n## Notes\n- Commit contains only Phase 5 UI implementation files.\n- Unrelated runtime metrics/session trace files remain unstaged in working tree and are intentionally excluded.