### PR TITLE
feat(ui): implement workspace CRUD UI

### DIFF
--- a/src/webapp/ui/src/components/workspaces/add-repository-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/add-repository-dialog.tsx
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { ModalDialog } from '@/components/ui/modal-dialog';
+import { InputField } from '@/components/ui/input-field';
+import { FormRow } from '@/components/ui/form-row';
+import { useAddRepository } from '@/hooks';
+
+export function AddRepositoryDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+}) {
+  const addRepository = useAddRepository();
+  const [repoId, setRepoId] = useState('');
+  const [name, setName] = useState('');
+  const [provider, setProvider] = useState<'github' | 'azure-devops' | 'gitlab' | 'local'>(
+    'github'
+  );
+  const [url, setUrl] = useState('');
+  const [defaultBranch, setDefaultBranch] = useState('main');
+
+  const handleSubmit = useCallback(() => {
+    if (!repoId.trim() || !name.trim() || !url.trim() || !defaultBranch.trim()) return;
+
+    addRepository.mutate(
+      {
+        workspaceId,
+        repository: {
+          id: repoId.trim(),
+          name: name.trim(),
+          provider,
+          url: url.trim(),
+          defaultBranch: defaultBranch.trim(),
+        },
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          setRepoId('');
+          setName('');
+          setProvider('github');
+          setUrl('');
+          setDefaultBranch('main');
+        },
+      }
+    );
+  }, [addRepository, repoId, name, provider, url, defaultBranch, workspaceId, onOpenChange]);
+
+  return (
+    <ModalDialog
+      title="Add Repository"
+      description="Register a repository with this workspace"
+      open={open}
+      onOpenChange={onOpenChange}
+      size="lg"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              !repoId.trim() ||
+              !name.trim() ||
+              !url.trim() ||
+              !defaultBranch.trim() ||
+              addRepository.isPending
+            }
+            loading={addRepository.isPending}
+          >
+            Add repository
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <InputField
+          label="Repository ID"
+          value={repoId}
+          onChange={(e) => setRepoId(e.target.value)}
+          placeholder="e.g., repo-frontend"
+        />
+        <InputField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <FormRow label="Provider">
+          <select
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value as typeof provider)}
+          >
+            <option value="github">GitHub</option>
+            <option value="azure-devops">Azure DevOps</option>
+            <option value="gitlab">GitLab</option>
+            <option value="local">Local</option>
+          </select>
+        </FormRow>
+        <InputField
+          label="Repository URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://github.com/owner/repo"
+        />
+        <InputField
+          label="Default Branch"
+          value={defaultBranch}
+          onChange={(e) => setDefaultBranch(e.target.value)}
+          placeholder="main"
+        />
+      </div>
+    </ModalDialog>
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/create-project-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/create-project-dialog.tsx
@@ -1,0 +1,79 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { ModalDialog } from '@/components/ui/modal-dialog';
+import { InputField } from '@/components/ui/input-field';
+import { useCreateProject } from '@/hooks';
+
+export function CreateProjectDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+}) {
+  const createProject = useCreateProject();
+  const [projectId, setProjectId] = useState('');
+  const [name, setName] = useState('');
+
+  const handleSubmit = useCallback(() => {
+    if (!projectId.trim() || !name.trim()) return;
+
+    createProject.mutate(
+      {
+        workspaceId,
+        project: {
+          id: projectId.trim(),
+          name: name.trim(),
+        },
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          setProjectId('');
+          setName('');
+        },
+      }
+    );
+  }, [createProject, projectId, name, workspaceId, onOpenChange]);
+
+  return (
+    <ModalDialog
+      title="New Project"
+      description="Create a new project in this workspace"
+      open={open}
+      onOpenChange={onOpenChange}
+      size="lg"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!projectId.trim() || !name.trim() || createProject.isPending}
+            loading={createProject.isPending}
+          >
+            Create project
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <InputField
+          label="Project ID"
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          placeholder="e.g., proj-data-pipeline"
+        />
+        <InputField
+          label="Project Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Project name"
+        />
+      </div>
+    </ModalDialog>
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/create-workspace-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/create-workspace-dialog.tsx
@@ -1,0 +1,78 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { ModalDialog } from '@/components/ui/modal-dialog';
+import { InputField } from '@/components/ui/input-field';
+import { useCreateWorkspace } from '@/hooks';
+
+export function CreateWorkspaceDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const createWorkspace = useCreateWorkspace();
+  const [id, setId] = useState('');
+  const [name, setName] = useState('');
+  const [owner, setOwner] = useState('');
+
+  const handleSubmit = useCallback(() => {
+    if (!id.trim() || !name.trim() || !owner.trim()) return;
+    createWorkspace.mutate(
+      { id: id.trim(), name: name.trim(), owner: owner.trim() },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          setId('');
+          setName('');
+          setOwner('');
+        },
+      }
+    );
+  }, [createWorkspace, id, name, owner, onOpenChange]);
+
+  return (
+    <ModalDialog
+      title="New Workspace"
+      description="Create a new workspace to organize repositories and projects."
+      open={open}
+      onOpenChange={onOpenChange}
+      size="lg"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!id.trim() || !name.trim() || !owner.trim() || createWorkspace.isPending}
+            loading={createWorkspace.isPending}
+          >
+            Create workspace
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <InputField
+          label="Workspace ID"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+          placeholder="e.g., ws-frontend-team"
+        />
+        <InputField
+          label="Workspace Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g., Frontend Team"
+        />
+        <InputField
+          label="Owner"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+          placeholder="e.g., john.doe@company.com"
+        />
+      </div>
+    </ModalDialog>
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/delete-project-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/delete-project-dialog.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useDeleteProject } from '@/hooks';
+import type { WorkspaceProject } from '@/lib/api-types';
+
+export function DeleteProjectDialog({
+  project,
+  workspaceId,
+  onClose,
+}: {
+  project: WorkspaceProject | null;
+  workspaceId: string;
+  onClose: () => void;
+}) {
+  const deleteProject = useDeleteProject();
+
+  const handleConfirm = useCallback(() => {
+    if (!project) return;
+    deleteProject.mutate({ projectId: project.id, workspaceId }, { onSuccess: () => onClose() });
+  }, [deleteProject, project, workspaceId, onClose]);
+
+  if (!project) return null;
+
+  return (
+    <ConfirmDialog
+      open={!!project}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title="Delete project?"
+      message={`Are you sure you want to delete the project "${project.name}"? This action cannot be undone.`}
+      confirmLabel="Yes, delete"
+      cancelLabel="No, cancel"
+      destructive
+      onConfirm={handleConfirm}
+    />
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/delete-workspace-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/delete-workspace-dialog.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useDeleteWorkspace } from '@/hooks';
+import type { WorkspaceSummary } from '@/lib/api-types';
+
+export function DeleteWorkspaceDialog({
+  workspace,
+  onClose,
+}: {
+  workspace: WorkspaceSummary | null;
+  onClose: () => void;
+}) {
+  const deleteWorkspace = useDeleteWorkspace();
+
+  const handleConfirm = useCallback(() => {
+    if (!workspace) return;
+    deleteWorkspace.mutate(workspace.id, {
+      onSuccess: () => onClose(),
+    });
+  }, [deleteWorkspace, workspace, onClose]);
+
+  if (!workspace) return null;
+
+  return (
+    <ConfirmDialog
+      open={!!workspace}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title="Delete workspace?"
+      message={`Are you sure you want to delete the workspace "${workspace.name}"? This action cannot be undone.`}
+      confirmLabel="Yes, delete"
+      cancelLabel="No, cancel"
+      destructive
+      onConfirm={handleConfirm}
+    />
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/edit-workspace-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/edit-workspace-dialog.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { ModalDialog } from '@/components/ui/modal-dialog';
+import { InputField } from '@/components/ui/input-field';
+import { useUpdateWorkspace } from '@/hooks';
+import type { WorkspaceSummary } from '@/lib/api-types';
+
+export function EditWorkspaceDialog({
+  workspace,
+  onClose,
+}: {
+  workspace: WorkspaceSummary | null;
+  onClose: () => void;
+}) {
+  const updateWorkspace = useUpdateWorkspace();
+  const [name, setName] = useState('');
+  const [owner, setOwner] = useState('');
+
+  useMemo(() => {
+    if (!workspace) return;
+    setName(workspace.name);
+    setOwner(workspace.owner);
+  }, [workspace]);
+
+  const handleSubmit = useCallback(() => {
+    if (!workspace) return;
+    if (!name.trim() || !owner.trim()) return;
+
+    updateWorkspace.mutate(
+      {
+        workspaceId: workspace.id,
+        updates: {
+          name: name.trim(),
+          owner: owner.trim(),
+        },
+      },
+      { onSuccess: () => onClose() }
+    );
+  }, [updateWorkspace, workspace, name, owner, onClose]);
+
+  if (!workspace) return null;
+
+  return (
+    <ModalDialog
+      title={`Edit workspace: ${workspace.id}`}
+      description="Update workspace details"
+      open={!!workspace}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      size="lg"
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!name.trim() || !owner.trim() || updateWorkspace.isPending}
+            loading={updateWorkspace.isPending}
+          >
+            Save changes
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <InputField
+          label="Workspace Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Workspace name"
+        />
+        <InputField
+          label="Owner"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+          placeholder="Owner email or identifier"
+        />
+      </div>
+    </ModalDialog>
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/index.ts
+++ b/src/webapp/ui/src/components/workspaces/index.ts
@@ -1,0 +1,9 @@
+export { CreateWorkspaceDialog } from './create-workspace-dialog';
+export { EditWorkspaceDialog } from './edit-workspace-dialog';
+export { DeleteWorkspaceDialog } from './delete-workspace-dialog';
+export { AddRepositoryDialog } from './add-repository-dialog';
+export { RemoveRepositoryDialog } from './remove-repository-dialog';
+export { CreateProjectDialog } from './create-project-dialog';
+export { DeleteProjectDialog } from './delete-project-dialog';
+export { RepositoriesSection } from './repositories-section';
+export { ProjectsSection } from './projects-section';

--- a/src/webapp/ui/src/components/workspaces/projects-section.tsx
+++ b/src/webapp/ui/src/components/workspaces/projects-section.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CreateProjectDialog } from './create-project-dialog';
+import { DeleteProjectDialog } from './delete-project-dialog';
+import { Trash2, Plus, Layers } from 'lucide-react';
+import type { WorkspaceProject } from '@/lib/api-types';
+
+export function ProjectsSection({
+  workspaceId,
+  projects,
+}: {
+  workspaceId: string;
+  projects: WorkspaceProject[];
+}) {
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [selectedForDeletion, setSelectedForDeletion] = useState<WorkspaceProject | null>(null);
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'active':
+        return 'bg-green-100 text-green-800';
+      case 'archived':
+        return 'bg-gray-100 text-gray-800';
+      case 'draft':
+        return 'bg-yellow-100 text-yellow-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <Layers className="size-4" />
+          Projects ({projects.length})
+        </h3>
+        <Button size="sm" variant="outline" onClick={() => setShowCreateDialog(true)}>
+          <Plus className="mr-1.5 size-3" />
+          New Project
+        </Button>
+      </div>
+
+      {projects.length === 0 ? (
+        <Card elevation="flat" className="p-4 text-center text-sm text-muted-foreground">
+          No projects created yet
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {projects.map((project) => (
+            <Card
+              key={project.id}
+              elevation="flat"
+              className="flex items-center justify-between p-3"
+            >
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm">{project.name}</span>
+                  <Badge className={getStatusColor(project.status)} variant="outline">
+                    {project.status}
+                  </Badge>
+                </div>
+                <div className="text-xs text-muted-foreground mt-1">
+                  {project.repositories.length} repositories
+                </div>
+                {project.sessions.length > 0 && (
+                  <div className="text-xs text-muted-foreground">
+                    {project.sessions.length} sessions
+                  </div>
+                )}
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-destructive hover:bg-destructive/10"
+                onClick={() => setSelectedForDeletion(project)}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <CreateProjectDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        workspaceId={workspaceId}
+      />
+
+      <DeleteProjectDialog
+        project={selectedForDeletion}
+        workspaceId={workspaceId}
+        onClose={() => setSelectedForDeletion(null)}
+      />
+    </div>
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/remove-repository-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/remove-repository-dialog.tsx
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { useRemoveRepository } from '@/hooks';
+import type { WorkspaceRepository } from '@/lib/api-types';
+
+export function RemoveRepositoryDialog({
+  repository,
+  workspaceId,
+  onClose,
+}: {
+  repository: WorkspaceRepository | null;
+  workspaceId: string;
+  onClose: () => void;
+}) {
+  const removeRepository = useRemoveRepository();
+
+  const handleConfirm = useCallback(() => {
+    if (!repository) return;
+    removeRepository.mutate(
+      { workspaceId, repositoryId: repository.id },
+      { onSuccess: () => onClose() }
+    );
+  }, [removeRepository, repository, workspaceId, onClose]);
+
+  if (!repository) return null;
+
+  return (
+    <ConfirmDialog
+      open={!!repository}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title="Remove repository?"
+      message={`Are you sure you want to remove "${repository.name}" from this workspace?`}
+      confirmLabel="Yes, remove"
+      cancelLabel="No, cancel"
+      destructive
+      onConfirm={handleConfirm}
+    />
+  );
+}

--- a/src/webapp/ui/src/components/workspaces/repositories-section.tsx
+++ b/src/webapp/ui/src/components/workspaces/repositories-section.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { AddRepositoryDialog } from './add-repository-dialog';
+import { RemoveRepositoryDialog } from './remove-repository-dialog';
+import { Trash2, Plus, GitFork } from 'lucide-react';
+import type { WorkspaceRepository } from '@/lib/api-types';
+
+export function RepositoriesSection({
+  workspaceId,
+  repositories,
+}: {
+  workspaceId: string;
+  repositories: WorkspaceRepository[];
+}) {
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [selectedForRemoval, setSelectedForRemoval] = useState<WorkspaceRepository | null>(null);
+
+  const getProviderColor = (provider: string) => {
+    switch (provider) {
+      case 'github':
+        return 'bg-gray-900 text-white';
+      case 'azure-devops':
+        return 'bg-blue-600 text-white';
+      case 'gitlab':
+        return 'bg-orange-600 text-white';
+      case 'local':
+        return 'bg-green-600 text-white';
+      default:
+        return 'bg-gray-400 text-white';
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <GitFork className="size-4" />
+          Repositories ({repositories.length})
+        </h3>
+        <Button size="sm" variant="outline" onClick={() => setShowAddDialog(true)}>
+          <Plus className="mr-1.5 size-3" />
+          Add Repository
+        </Button>
+      </div>
+
+      {repositories.length === 0 ? (
+        <Card elevation="flat" className="p-4 text-center text-sm text-muted-foreground">
+          No repositories added yet
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {repositories.map((repo) => (
+            <Card key={repo.id} elevation="flat" className="flex items-center justify-between p-3">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-sm">{repo.name}</span>
+                  <Badge className={`${getProviderColor(repo.provider)} text-xs`}>
+                    {repo.provider}
+                  </Badge>
+                </div>
+                <div className="text-xs text-muted-foreground mt-1">{repo.url}</div>
+                {repo.defaultBranch && (
+                  <div className="text-xs text-muted-foreground">
+                    Default branch: <span className="font-mono">{repo.defaultBranch}</span>
+                  </div>
+                )}
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-destructive hover:bg-destructive/10"
+                onClick={() => setSelectedForRemoval(repo)}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <AddRepositoryDialog
+        open={showAddDialog}
+        onOpenChange={setShowAddDialog}
+        workspaceId={workspaceId}
+      />
+
+      <RemoveRepositoryDialog
+        repository={selectedForRemoval}
+        workspaceId={workspaceId}
+        onClose={() => setSelectedForRemoval(null)}
+      />
+    </div>
+  );
+}

--- a/src/webapp/ui/src/hooks/index.ts
+++ b/src/webapp/ui/src/hooks/index.ts
@@ -130,8 +130,19 @@ export {
   useRejectWithComment,
 } from './use-cockpit';
 
-/* Workspaces (UI-014) */
-export { useWorkspaces, useWorkspaceDetail } from './use-workspaces';
+/* Workspaces (UI-014, M25-014) */
+export {
+  useWorkspaces,
+  useWorkspaceDetail,
+  useCreateWorkspace,
+  useUpdateWorkspace,
+  useDeleteWorkspace,
+  useAddRepository,
+  useRemoveRepository,
+  useCreateProject,
+  useUpdateProject,
+  useDeleteProject,
+} from './use-workspaces';
 
 /* Prompts & Contracts (UI-015) */
 export { usePromptContractAssets } from './use-prompt-contracts';

--- a/src/webapp/ui/src/hooks/use-workspaces.ts
+++ b/src/webapp/ui/src/hooks/use-workspaces.ts
@@ -1,7 +1,32 @@
-import { useQuery } from '@tanstack/react-query';
-import { apiGet } from '@/lib/api-client';
+/**
+ * Workspaces CRUD hooks — TanStack Query wrappers for /api/workspaces/* (M25-014).
+ *
+ * Queries:
+ *   - useWorkspaces() — List all workspaces
+ *   - useWorkspaceDetail() — Get workspace + projects
+ *
+ * Mutations:
+ *   - useCreateWorkspace() — Create new workspace
+ *   - useUpdateWorkspace() — Update workspace name/owner
+ *   - useDeleteWorkspace() — Delete workspace
+ *   - useAddRepository() — Add repository to workspace
+ *   - useRemoveRepository() — Remove repository from workspace
+ *   - useCreateProject() — Create project in workspace
+ *   - useUpdateProject() — Update project
+ *   - useDeleteProject() — Delete project
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiGet, apiPost, apiPut, apiDelete } from '@/lib/api-client';
 import { queryKeys } from '@/lib/query-keys';
-import type { WorkspacesListResponse, WorkspaceDetailResponse } from '@/lib/api-types';
+import { showToast } from '@/components/ui/toast-system';
+import type {
+  WorkspacesListResponse,
+  WorkspaceDetailResponse,
+  WorkspaceSummary,
+  WorkspaceProject,
+  OkResponse,
+} from '@/lib/api-types';
 
 /** List all registered workspaces. */
 export function useWorkspaces() {
@@ -20,5 +45,171 @@ export function useWorkspaceDetail(workspaceId: string | null) {
     queryFn: () =>
       apiGet<WorkspaceDetailResponse>(`/workspaces/${encodeURIComponent(workspaceId ?? '')}`),
     enabled: Boolean(workspaceId),
+  });
+}
+
+/** Create a new workspace. */
+export function useCreateWorkspace() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: { id: string; name: string; owner: string }) =>
+      apiPost<OkResponse & { workspace: WorkspaceSummary }>('/workspaces', payload),
+
+    onSuccess: (data) => {
+      showToast.success(`Workspace "${data.workspace.name}" created`);
+      qc.invalidateQueries({ queryKey: queryKeys.workspaces.all });
+    },
+  });
+}
+
+/** Update workspace name or owner. */
+export function useUpdateWorkspace() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: { workspaceId: string; updates: { name?: string; owner?: string } }) =>
+      apiPut<OkResponse & { workspace: WorkspaceSummary }>(
+        `/workspaces/${encodeURIComponent(payload.workspaceId)}`,
+        payload.updates
+      ),
+
+    onSuccess: (data) => {
+      showToast.success('Workspace updated');
+      qc.invalidateQueries({ queryKey: queryKeys.workspaces.all });
+      qc.invalidateQueries({
+        queryKey: queryKeys.workspaces.detail(data.workspace.id),
+      });
+    },
+  });
+}
+
+/** Delete a workspace. */
+export function useDeleteWorkspace() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (workspaceId: string) =>
+      apiDelete<OkResponse>(`/workspaces/${encodeURIComponent(workspaceId)}`),
+
+    onSuccess: () => {
+      showToast.success('Workspace deleted');
+      qc.invalidateQueries({ queryKey: queryKeys.workspaces.all });
+    },
+  });
+}
+
+/** Add a repository to a workspace. */
+export function useAddRepository() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: {
+      workspaceId: string;
+      repository: {
+        id: string;
+        name: string;
+        provider: 'github' | 'azure-devops' | 'gitlab' | 'local';
+        url: string;
+        defaultBranch: string;
+        tags?: string[];
+      };
+    }) =>
+      apiPost<OkResponse & { workspace: WorkspaceSummary }>(
+        `/workspaces/${encodeURIComponent(payload.workspaceId)}/repositories`,
+        payload.repository
+      ),
+
+    onSuccess: (_data, variables) => {
+      showToast.success('Repository added');
+      qc.invalidateQueries({
+        queryKey: queryKeys.workspaces.detail(variables.workspaceId),
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.workspaces.all });
+    },
+  });
+}
+
+/** Remove a repository from a workspace. */
+export function useRemoveRepository() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: { workspaceId: string; repositoryId: string }) =>
+      apiDelete<OkResponse>(
+        `/workspaces/${encodeURIComponent(payload.workspaceId)}/repositories/${encodeURIComponent(payload.repositoryId)}`
+      ),
+
+    onSuccess: (_data, variables) => {
+      showToast.success('Repository removed');
+      qc.invalidateQueries({
+        queryKey: queryKeys.workspaces.detail(variables.workspaceId),
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.workspaces.all });
+    },
+  });
+}
+
+/** Create a project in a workspace. */
+export function useCreateProject() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: {
+      workspaceId: string;
+      project: { id: string; name: string; repositories?: string[] };
+    }) =>
+      apiPost<OkResponse & { project: WorkspaceProject }>(
+        `/workspaces/${encodeURIComponent(payload.workspaceId)}/projects`,
+        payload.project
+      ),
+
+    onSuccess: (_data, variables) => {
+      showToast.success('Project created');
+      qc.invalidateQueries({
+        queryKey: queryKeys.workspaces.detail(variables.workspaceId),
+      });
+    },
+  });
+}
+
+/** Update a project. */
+export function useUpdateProject() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: {
+      projectId: string;
+      workspaceId: string;
+      updates: { name?: string; status?: 'active' | 'archived' | 'draft' };
+    }) =>
+      apiPut<OkResponse & { project: WorkspaceProject }>(
+        `/projects/${encodeURIComponent(payload.projectId)}`,
+        payload.updates
+      ),
+
+    onSuccess: (_data, variables) => {
+      showToast.success('Project updated');
+      qc.invalidateQueries({
+        queryKey: queryKeys.workspaces.detail(variables.workspaceId),
+      });
+    },
+  });
+}
+
+/** Delete a project. */
+export function useDeleteProject() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: { projectId: string; workspaceId: string }) =>
+      apiDelete<OkResponse>(`/projects/${encodeURIComponent(payload.projectId)}`),
+
+    onSuccess: (_data, variables) => {
+      showToast.success('Project deleted');
+      qc.invalidateQueries({
+        queryKey: queryKeys.workspaces.detail(variables.workspaceId),
+      });
+    },
   });
 }

--- a/src/webapp/ui/src/pages/workspaces/workspaces-page.tsx
+++ b/src/webapp/ui/src/pages/workspaces/workspaces-page.tsx
@@ -2,17 +2,28 @@ import { useEffect, useMemo, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { EmptyState } from '@/components/ui/empty-state';
 import { PageShell } from '@/components/ui/page-shell';
 import { PageHeader } from '@/components/layout/page-header';
 import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
+import {
+  CreateWorkspaceDialog,
+  EditWorkspaceDialog,
+  DeleteWorkspaceDialog,
+  RepositoriesSection,
+  ProjectsSection,
+} from '@/components/workspaces';
 import { useWorkspaceDetail, useWorkspaces } from '@/hooks';
-import { FolderKanban, GitFork, Layers, RefreshCw } from 'lucide-react';
+import { FolderKanban, Plus, Edit2, Trash2, RefreshCw } from 'lucide-react';
 
 export default function WorkspacesPage() {
   const { data, isLoading, error, refetch } = useWorkspaces();
   const workspaces = useMemo(() => data?.workspaces ?? [], [data?.workspaces]);
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+
+  // Dialog states
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [workspaceToEdit, setWorkspaceToEdit] = useState<typeof selectedWorkspaceId>(null);
+  const [workspaceToDelete, setWorkspaceToDelete] = useState<typeof selectedWorkspaceId>(null);
 
   useEffect(() => {
     if (!selectedWorkspaceId && workspaces.length > 0) {
@@ -65,154 +76,161 @@ export default function WorkspacesPage() {
   }, [detail?.projects.length, selectedWorkspace, workspaces]);
 
   return (
-    <PageShell
-      isLoading={isLoading}
-      loadingLabel="Loading workspaces..."
-      error={error as Error | null}
-      onRetry={() => refetch()}
-      isEmpty={workspaces.length === 0}
-      emptyState={{
-        icon: <FolderKanban className="size-8" />,
-        title: 'No workspaces found',
-        description: 'Create a workspace to start grouping repositories and projects.',
-      }}
-    >
-      <div className="space-y-6 p-6" data-testid="workspaces-page">
-        <PageHeader
-          title="Workspaces"
-          subtitle="Manage workspace-level context, repositories, and projects for orchestration runs."
-          chips={[
-            {
-              id: 'workspaces-chip-total',
-              label: `${workspaces.length} total`,
-              tone: workspaces.length > 0 ? 'info' : 'default',
-            },
-            {
-              id: 'workspaces-chip-selection',
-              label: selectedWorkspace?.id ?? 'No selection',
-              tone: selectedWorkspace ? 'success' : 'default',
-            },
-          ]}
-          actions={
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="mr-1.5 size-3" />
-              Refresh
-            </Button>
-          }
-        />
-
-        <ContextStrip items={contextItems} />
-
-        <div className="grid gap-4 lg:grid-cols-[300px_1fr]">
-          <Card elevation="flat" className="space-y-2 p-3">
-            {workspaces.map((workspace) => (
-              <button
-                key={workspace.id}
-                type="button"
-                onClick={() => setSelectedWorkspaceId(workspace.id)}
-                className={`w-full rounded-xl border px-3 py-2 text-left transition ${
-                  workspace.id === selectedWorkspace?.id
-                    ? 'border-info/40 bg-info/10'
-                    : 'border-border/70 bg-background hover:bg-card'
-                }`}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-semibold">{workspace.name}</p>
-                    <p className="text-xs text-muted-foreground">{workspace.owner}</p>
-                  </div>
-                  <Badge variant="outline">{workspace.repositories.length} repos</Badge>
-                </div>
-              </button>
-            ))}
-          </Card>
-
-          <PageShell
-            isLoading={detailLoading}
-            loadingLabel="Loading workspace detail..."
-            error={detailError as Error | null}
-            onRetry={() => refetchDetail()}
-            isEmpty={!detail || !detail.workspace}
-            emptyState={{
-              icon: <Layers className="size-8" />,
-              title: 'Select a workspace',
-              description: 'Choose a workspace from the left panel to inspect details.',
-            }}
-          >
-            {detail && (
-              <div className="space-y-4">
-                <Card elevation="flat" className="p-4">
-                  <div className="flex items-center justify-between gap-2">
-                    <div>
-                      <h2 className="text-lg font-semibold">{detail.workspace.name}</h2>
-                      <p className="text-sm text-muted-foreground">
-                        Owned by {detail.workspace.owner}
-                      </p>
-                    </div>
-                    <Badge variant="info">{detail.projects.length} projects</Badge>
-                  </div>
-                </Card>
-
-                <div className="grid gap-4 xl:grid-cols-2">
-                  <Card elevation="flat" className="space-y-3 p-4">
-                    <div className="flex items-center gap-2">
-                      <GitFork className="size-4 text-info" />
-                      <h3 className="text-sm font-semibold">Repositories</h3>
-                    </div>
-                    {detail.workspace.repositories.length === 0 ? (
-                      <EmptyState
-                        title="No repositories"
-                        description="This workspace has no linked repositories yet."
-                      />
-                    ) : (
-                      <div className="space-y-2">
-                        {detail.workspace.repositories.map((repo) => (
-                          <div key={repo.id} className="rounded-lg border border-border/70 p-3">
-                            <div className="flex items-center justify-between gap-2">
-                              <p className="text-sm font-medium">{repo.name}</p>
-                              <Badge variant="neutral">{repo.provider}</Badge>
-                            </div>
-                            <p className="mt-1 text-xs text-muted-foreground">{repo.url}</p>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </Card>
-
-                  <Card elevation="flat" className="space-y-3 p-4">
-                    <div className="flex items-center gap-2">
-                      <Layers className="size-4 text-info" />
-                      <h3 className="text-sm font-semibold">Projects</h3>
-                    </div>
-                    {detail.projects.length === 0 ? (
-                      <EmptyState
-                        title="No projects"
-                        description="Projects can be created from the workspace management APIs."
-                      />
-                    ) : (
-                      <div className="space-y-2">
-                        {detail.projects.map((project) => (
-                          <div key={project.id} className="rounded-lg border border-border/70 p-3">
-                            <div className="flex items-center justify-between gap-2">
-                              <p className="text-sm font-medium">{project.name}</p>
-                              <Badge variant={project.status === 'active' ? 'success' : 'outline'}>
-                                {project.status}
-                              </Badge>
-                            </div>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {project.repositories.length} linked repositories
-                            </p>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </Card>
-                </div>
+    <>
+      <PageShell
+        isLoading={isLoading}
+        loadingLabel="Loading workspaces..."
+        error={error as Error | null}
+        onRetry={() => refetch()}
+        isEmpty={workspaces.length === 0}
+        emptyState={{
+          icon: <FolderKanban className="size-8" />,
+          title: 'No workspaces found',
+          description: 'Create a workspace to start grouping repositories and projects.',
+          action: {
+            label: 'Create workspace',
+            onClick: () => setShowCreateDialog(true),
+          },
+        }}
+      >
+        <div className="space-y-6 p-6" data-testid="workspaces-page">
+          <PageHeader
+            title="Workspaces"
+            subtitle="Manage workspace-level context, repositories, and projects for orchestration runs."
+            chips={[
+              {
+                id: 'workspaces-chip-total',
+                label: `${workspaces.length} total`,
+                tone: workspaces.length > 0 ? 'info' : 'default',
+              },
+              {
+                id: 'workspaces-chip-selection',
+                label: selectedWorkspace?.id ?? 'No selection',
+                tone: selectedWorkspace ? 'success' : 'default',
+              },
+            ]}
+            actions={
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={() => refetch()}>
+                  <RefreshCw className="mr-1.5 size-3" />
+                  Refresh
+                </Button>
+                <Button size="sm" onClick={() => setShowCreateDialog(true)}>
+                  <Plus className="mr-1.5 size-3" />
+                  Workspace
+                </Button>
               </div>
-            )}
-          </PageShell>
+            }
+          />
+
+          <ContextStrip items={contextItems} />
+
+          <div className="grid gap-4 lg:grid-cols-[300px_1fr]">
+            <Card elevation="flat" className="space-y-2 p-3">
+              {workspaces.map((workspace) => (
+                <button
+                  key={workspace.id}
+                  type="button"
+                  onClick={() => setSelectedWorkspaceId(workspace.id)}
+                  className={`w-full rounded-xl border px-3 py-2 text-left transition ${
+                    workspace.id === selectedWorkspace?.id
+                      ? 'border-info/40 bg-info/10'
+                      : 'border-border/70 bg-background hover:bg-card'
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold truncate">{workspace.name}</p>
+                      <p className="text-xs text-muted-foreground truncate">{workspace.owner}</p>
+                    </div>
+                    <Badge variant="outline" className="whitespace-nowrap">
+                      {workspace.repositories.length} repos
+                    </Badge>
+                  </div>
+                </button>
+              ))}
+            </Card>
+
+            <PageShell
+              isLoading={detailLoading}
+              loadingLabel="Loading workspace detail..."
+              error={detailError as Error | null}
+              onRetry={() => refetchDetail()}
+              isEmpty={!detail || !detail.workspace}
+              emptyState={{
+                icon: <FolderKanban className="size-8" />,
+                title: 'Select a workspace',
+                description:
+                  'Choose a workspace from the left panel to view and manage its details.',
+              }}
+            >
+              {detail && selectedWorkspace && (
+                <div className="space-y-4">
+                  <Card elevation="flat" className="p-4">
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex-1">
+                        <h2 className="text-lg font-semibold">{detail.workspace.name}</h2>
+                        <p className="text-sm text-muted-foreground">
+                          Owned by {detail.workspace.owner}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setWorkspaceToEdit(selectedWorkspace.id)}
+                        >
+                          <Edit2 className="size-4" />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="text-destructive hover:bg-destructive/10"
+                          onClick={() => setWorkspaceToDelete(selectedWorkspace.id)}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </Card>
+
+                  <div className="grid gap-4 xl:grid-cols-2">
+                    <RepositoriesSection
+                      workspaceId={selectedWorkspace.id}
+                      repositories={detail.workspace.repositories}
+                    />
+
+                    <ProjectsSection
+                      workspaceId={selectedWorkspace.id}
+                      projects={detail.projects}
+                    />
+                  </div>
+                </div>
+              )}
+            </PageShell>
+          </div>
         </div>
-      </div>
-    </PageShell>
+      </PageShell>
+
+      {/* Dialogs must stay mounted even when PageShell renders empty/error states */}
+      <CreateWorkspaceDialog open={showCreateDialog} onOpenChange={setShowCreateDialog} />
+
+      <EditWorkspaceDialog
+        workspace={
+          workspaceToEdit ? (workspaces.find((w) => w.id === workspaceToEdit) ?? null) : null
+        }
+        onClose={() => setWorkspaceToEdit(null)}
+      />
+
+      <DeleteWorkspaceDialog
+        workspace={
+          workspaceToDelete ? (workspaces.find((w) => w.id === workspaceToDelete) ?? null) : null
+        }
+        onClose={() => {
+          setWorkspaceToDelete(null);
+          setSelectedWorkspaceId(null);
+        }}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary\n- implement full workspace CRUD UI flows in Workspaces page\n- add workspace mutation hooks for create/update/delete, repository add/remove, and project create/update/delete\n- add dedicated dialogs and sections for workspace, repository, and project management\n- fix empty-state create button by keeping dialogs mounted outside PageShell\n\n## Validation\n- npm run format\n- npm run lint\n- npm run test:coverage\n- npm run build\n\n## Notes\n- commit includes only workspace UI and hook files\n- excludes generated runtime/doc artifacts in working tree