### PR TITLE
Enforce MCP runtime permissions in tool execution path

### DIFF
--- a/platform/engine/agent-runtime-adapter.ts
+++ b/platform/engine/agent-runtime-adapter.ts
@@ -147,6 +147,7 @@ interface ProviderBackedRuntimeAdapterConfig {
   toolExecutor?: Pick<ToolExecutor, 'execute'>;
   toolAudit?: { logToolExecution(event: ToolExecutionAuditEvent): void };
   toolCatalogPath?: string;
+  runtimeManifestDir?: string;
 }
 
 interface MockRuntimeAdapterConfig {
@@ -687,6 +688,7 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
   private readonly _toolExecutor: Pick<ToolExecutor, 'execute'>;
   private readonly _toolAudit?: { logToolExecution(event: ToolExecutionAuditEvent): void };
   private readonly _toolCatalogPath?: string;
+  private readonly _runtimeManifestDir?: string;
 
   constructor(config: ProviderBackedRuntimeAdapterConfig) {
     super(config.outputDir);
@@ -701,6 +703,7 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
     this._toolExecutor = config.toolExecutor || createDefaultToolExecutor();
     this._toolAudit = config.toolAudit;
     this._toolCatalogPath = config.toolCatalogPath;
+    this._runtimeManifestDir = config.runtimeManifestDir;
   }
 
   private _createToolMiddleware(audit?: {
@@ -710,7 +713,15 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
       toolExecutor: this._toolExecutor,
       audit,
       catalogPath: this._toolCatalogPath,
+      runtimeManifestDir: this._runtimeManifestDir,
     });
+  }
+
+  private _deriveEnvScope(profile: string | undefined): 'dev' | 'test' | 'prod' {
+    if (!profile) return 'dev';
+    if (profile.startsWith('production-')) return 'prod';
+    if (profile.startsWith('test-')) return 'test';
+    return 'dev';
   }
 
   private async _completeWithToolExecution(options: {
@@ -722,6 +733,8 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
     policy: {
       role?: 'viewer' | 'operator' | 'admin';
       profile?: string;
+      agentId?: string;
+      envScope?: 'dev' | 'test' | 'prod';
       traceId: string;
       approvedActions?: unknown;
     };
@@ -772,6 +785,8 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
             {
               role: policy.role,
               profile: policy.profile,
+              agentId: policy.agentId,
+              envScope: policy.envScope,
               traceId: policy.traceId,
               approvedActions: policy.approvedActions,
             }
@@ -940,6 +955,11 @@ export class ProviderBackedLlmRuntimeAdapter extends FileProducingRuntimeAdapter
           profile:
             runtimeContext.profile ||
             (runtimeContext.sessionState as { profile?: string } | undefined)?.profile,
+          agentId: agent.id,
+          envScope: this._deriveEnvScope(
+            runtimeContext.profile ||
+              (runtimeContext.sessionState as { profile?: string } | undefined)?.profile
+          ),
           traceId: toolTraceId,
           approvedActions: resolvedPolicyApprovals,
         },

--- a/platform/engine/tool-execution-middleware.ts
+++ b/platform/engine/tool-execution-middleware.ts
@@ -16,6 +16,8 @@ export type ToolExecutionRole = 'viewer' | 'operator' | 'admin';
 export interface ToolExecutionPolicy {
   role?: ToolExecutionRole;
   profile?: string;
+  agentId?: string;
+  envScope?: 'dev' | 'test' | 'prod';
   traceId?: string;
   actor?: string;
   approvedActions?: unknown;
@@ -70,6 +72,22 @@ interface ApprovalResolution {
 interface SideEffectPolicySpec {
   check: string;
   policyId: string;
+}
+
+interface RuntimeToolPermissionRecord {
+  toolId: string;
+  permissionLevel: 'N' | 'D' | 'R' | 'P' | 'W' | 'A' | 'X';
+  approvalRequired: boolean;
+  blocked: boolean;
+}
+
+interface RuntimeManifestRecord {
+  agentId: string;
+  generatedAt: string;
+  servers: Array<{
+    serverId: string;
+    tools: RuntimeToolPermissionRecord[];
+  }>;
 }
 
 const C3_POLICY_BY_TOOL: Record<string, SideEffectPolicySpec> = {
@@ -221,6 +239,19 @@ function resolvePolicyApproval(toolId: string, approvedActions: unknown): Approv
   return { approved, decisionRefs: [...decisionRefs] };
 }
 
+function resolveAnyPolicyApproval(toolIds: string[], approvedActions: unknown): ApprovalResolution {
+  const refs = new Set<string>();
+  let approved = false;
+  for (const toolId of toolIds) {
+    const resolution = resolvePolicyApproval(toolId, approvedActions);
+    approved = approved || resolution.approved;
+    for (const ref of resolution.decisionRefs) {
+      refs.add(ref);
+    }
+  }
+  return { approved, decisionRefs: [...refs] };
+}
+
 function requiresExplicitPolicyApproval(toolId: string): boolean {
   return (
     toolId === 'tool.files.write' || toolId === 'tool.git.commit' || toolId === 'tool.github.issue'
@@ -241,6 +272,32 @@ function deriveRequiredRole(tool: CanonicalTool, profile: string): ToolExecution
   }
 
   return 'operator';
+}
+
+function deriveEnvScope(
+  profile: string,
+  requested?: ToolExecutionPolicy['envScope']
+): 'dev' | 'test' | 'prod' {
+  if (requested === 'dev' || requested === 'test' || requested === 'prod') {
+    return requested;
+  }
+  if (profile.startsWith('production-')) return 'prod';
+  if (profile.startsWith('test-')) return 'test';
+  return 'dev';
+}
+
+function isMutationTool(tool: CanonicalTool): boolean {
+  return !tool.capabilities?.readOnly;
+}
+
+function hasPermissionForOperation(
+  level: RuntimeToolPermissionRecord['permissionLevel'],
+  mutation: boolean
+): boolean {
+  if (level === 'N' || level === 'X') return false;
+  if (!mutation)
+    return level === 'D' || level === 'R' || level === 'P' || level === 'W' || level === 'A';
+  return level === 'P' || level === 'W' || level === 'A';
 }
 
 function toToolDefinition(tool: CanonicalTool): {
@@ -289,17 +346,106 @@ export class ToolExecutionMiddleware {
   private readonly _catalog: ToolsCatalog;
   private readonly _byId: Map<string, CanonicalTool>;
   private readonly _policies: Policy[];
+  private readonly _runtimeManifestDir: string;
 
   constructor(options: {
     toolExecutor: { execute<T = unknown>(request: ToolRequest): Promise<ToolExecutionResult<T>> };
     audit?: ToolExecutionAuditSink;
     catalogPath?: string;
+    runtimeManifestDir?: string;
   }) {
     this._toolExecutor = options.toolExecutor;
     this._audit = options.audit;
     this._catalog = readToolsCatalog(options.catalogPath);
     this._byId = new Map((this._catalog.tools || []).map((tool) => [tool.id, tool]));
     this._policies = resolvePolicyInheritance(loadAllPolicyPacks(POLICY_STORE));
+    this._runtimeManifestDir =
+      options.runtimeManifestDir || path.resolve(process.cwd(), '.generated', 'runtime-manifests');
+  }
+
+  private _readRuntimeManifest(agentId: string): RuntimeManifestRecord | null {
+    const filePath = path.join(this._runtimeManifestDir, `${agentId}.json`);
+    if (!existsSync(filePath)) {
+      return null;
+    }
+    try {
+      return JSON.parse(readFileSync(filePath, 'utf8')) as RuntimeManifestRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  private _resolveRuntimePermission(
+    agentId: string,
+    serverId: string,
+    operation: string
+  ): RuntimeToolPermissionRecord | null {
+    const manifest = this._readRuntimeManifest(agentId);
+    if (!manifest) return null;
+    const server = manifest.servers.find((entry) => entry.serverId === serverId);
+    if (!server) return null;
+
+    const toolId = `${serverId}.${operation}`;
+    const specific = server.tools.find((tool) => tool.toolId === toolId);
+    if (specific) return specific;
+
+    const fallback = server.tools.find((tool) => tool.toolId === `${serverId}.default`);
+    return fallback || null;
+  }
+
+  private _evaluateRuntimePermissionGate(options: {
+    tool: CanonicalTool;
+    toolId: string;
+    target: string;
+    operation: string;
+    policy: ToolExecutionPolicy;
+    profile: string;
+  }): { allowed: boolean; message?: string; decisionRefs: string[] } {
+    const envScope = deriveEnvScope(options.profile, options.policy.envScope);
+    const agentId = options.policy.agentId;
+    if (!agentId) {
+      return { allowed: true, decisionRefs: [] };
+    }
+
+    const resolved = this._resolveRuntimePermission(agentId, options.target, options.operation);
+    if (!resolved) {
+      return { allowed: true, decisionRefs: [] };
+    }
+
+    if (resolved.blocked || resolved.permissionLevel === 'X' || resolved.permissionLevel === 'N') {
+      return {
+        allowed: false,
+        message: `Tool '${options.toolId}' is blocked by resolved permissions for env_scope '${envScope}'.`,
+        decisionRefs: [],
+      };
+    }
+
+    const mutation = isMutationTool(options.tool);
+    if (!hasPermissionForOperation(resolved.permissionLevel, mutation)) {
+      return {
+        allowed: false,
+        message: `Tool '${options.toolId}' is not permitted by resolved permission level '${resolved.permissionLevel}' for env_scope '${envScope}'.`,
+        decisionRefs: [],
+      };
+    }
+
+    if (!resolved.approvalRequired) {
+      return { allowed: true, decisionRefs: [] };
+    }
+
+    const approval = resolveAnyPolicyApproval(
+      [options.toolId, `${options.target}.${options.operation}`],
+      options.policy.approvedActions
+    );
+    if (!approval.approved) {
+      return {
+        allowed: false,
+        message: `Tool '${options.toolId}' requires explicit policy approval for env_scope '${envScope}'.`,
+        decisionRefs: approval.decisionRefs,
+      };
+    }
+
+    return { allowed: true, decisionRefs: approval.decisionRefs };
   }
 
   private _evaluateSideEffectPolicy(
@@ -434,6 +580,34 @@ export class ToolExecutionMiddleware {
     if (typeof target !== 'string' || typeof operation !== 'string') {
       throw new ToolValidationError(
         `Tool call '${toolId}' must include string arguments 'target' and 'operation'.`
+      );
+    }
+
+    const runtimePermissionGate = this._evaluateRuntimePermissionGate({
+      tool,
+      toolId,
+      target,
+      operation,
+      policy,
+      profile,
+    });
+    if (!runtimePermissionGate.allowed) {
+      const event: ToolExecutionAuditEvent = {
+        timestamp: new Date().toISOString(),
+        traceId,
+        toolCallId: call.id,
+        toolId,
+        role,
+        profile,
+        paramsHash,
+        success: false,
+        errorCode: 'TOOL_POLICY_BLOCKED',
+        decisionRefs: runtimePermissionGate.decisionRefs,
+        error: runtimePermissionGate.message,
+      };
+      this._audit?.logToolExecution(event);
+      throw new ToolAuthorizationError(
+        event.error || 'Resolved permission gate blocked tool operation'
       );
     }
 

--- a/src/webapp/plugins/mcp-governance/cli.ts
+++ b/src/webapp/plugins/mcp-governance/cli.ts
@@ -30,6 +30,8 @@ function printUsage(): void {
       '  npm run plugin -- bootstrap --apply',
       '  npm run plugin -- agents sync [--apply|--dry-run]',
       '  npm run plugin -- mcp sync [--apply|--dry-run]',
+      '  npm run plugin -- policies sync [--apply|--dry-run]',
+      '  npm run plugin -- tool-policies sync [--apply|--dry-run]',
       '  npm run plugin -- runtime build',
       '  npm run plugin -- doctor',
       '',
@@ -79,9 +81,11 @@ async function run(overrideProjectRoot?: string): Promise<void> {
   if (cmd === 'bootstrap') {
     const migration = await service.runSqliteMigrations();
     const apply = parsed.apply || !parsed.dryRun;
-    const [agentSync, serverSync] = await Promise.all([
+    const [agentSync, serverSync, serverPolicySync, toolPolicySync] = await Promise.all([
       service.syncAgents(await service.getDefinedAgents(), { dryRun: !apply }),
       service.syncServers(await service.getDefinedServers(), { dryRun: !apply }),
+      service.syncServerPolicies(await service.getDefinedPolicies(), { dryRun: !apply }),
+      service.syncToolPolicies(await service.getDefinedToolPolicies(), { dryRun: !apply }),
     ]);
     process.stdout.write(
       `${JSON.stringify(
@@ -92,6 +96,8 @@ async function run(overrideProjectRoot?: string): Promise<void> {
           migration,
           agents: agentSync,
           servers: serverSync,
+          serverPolicies: serverPolicySync,
+          toolPolicies: toolPolicySync,
         },
         null,
         2
@@ -114,6 +120,28 @@ async function run(overrideProjectRoot?: string): Promise<void> {
     const result = await service.syncServers(await service.getDefinedServers(), { dryRun: !apply });
     process.stdout.write(
       `${JSON.stringify({ ok: true, command: 'mcp sync', apply, ...result }, null, 2)}\n`
+    );
+    return;
+  }
+
+  if (cmd === 'policies' && sub === 'sync') {
+    const apply = parsed.apply || !parsed.dryRun;
+    const result = await service.syncServerPolicies(await service.getDefinedPolicies(), {
+      dryRun: !apply,
+    });
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, command: 'policies sync', apply, ...result }, null, 2)}\n`
+    );
+    return;
+  }
+
+  if (cmd === 'tool-policies' && sub === 'sync') {
+    const apply = parsed.apply || !parsed.dryRun;
+    const result = await service.syncToolPolicies(await service.getDefinedToolPolicies(), {
+      dryRun: !apply,
+    });
+    process.stdout.write(
+      `${JSON.stringify({ ok: true, command: 'tool-policies sync', apply, ...result }, null, 2)}\n`
     );
     return;
   }

--- a/src/webapp/plugins/mcp-governance/defaults.ts
+++ b/src/webapp/plugins/mcp-governance/defaults.ts
@@ -5,8 +5,15 @@ import {
   defineEnvironmentPolicies,
   defineMcpServers,
   definePolicies,
+  defineToolPolicies,
 } from './factories';
-import type { AgentType, AgentServerPolicy, EnvironmentPolicy, McpServerRegistry } from './types';
+import type {
+  AgentToolPolicy,
+  AgentType,
+  AgentServerPolicy,
+  EnvironmentPolicy,
+  McpServerRegistry,
+} from './types';
 
 export const DEFAULT_AGENTS: AgentType[] = defineAgents([
   {
@@ -156,5 +163,25 @@ export const DEFAULT_ENVIRONMENT_POLICIES: EnvironmentPolicy[] = defineEnvironme
     env: 'prod',
     defaultPermission: 'R',
     writeRequiresApproval: true,
+  },
+]);
+
+export const DEFAULT_TOOL_POLICIES: AgentToolPolicy[] = defineToolPolicies([
+  {
+    agentId: 'orchestrator',
+    serverId: 'governance-approval',
+    toolId: 'governance-approval.approve_request',
+    overrideMode: 'set',
+    permission: 'A',
+    approvalRequired: true,
+    blocked: false,
+    envScope: 'prod',
+  },
+  {
+    agentId: 'documentation',
+    serverId: 'workspace-management',
+    toolId: 'workspace-management.delete_workspace',
+    overrideMode: 'deny',
+    blocked: true,
   },
 ]);

--- a/src/webapp/plugins/mcp-governance/factories.ts
+++ b/src/webapp/plugins/mcp-governance/factories.ts
@@ -1,6 +1,12 @@
 // Copyright (c) 2026 Robert Agterhuis. MIT License.
 
-import type { AgentType, McpServerRegistry, AgentServerPolicy, EnvironmentPolicy } from './types';
+import type {
+  AgentToolPolicy,
+  AgentType,
+  McpServerRegistry,
+  AgentServerPolicy,
+  EnvironmentPolicy,
+} from './types';
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -19,5 +25,9 @@ export function definePolicies(policies: AgentServerPolicy[]): AgentServerPolicy
 }
 
 export function defineEnvironmentPolicies(policies: EnvironmentPolicy[]): EnvironmentPolicy[] {
+  return clone(policies);
+}
+
+export function defineToolPolicies(policies: AgentToolPolicy[]): AgentToolPolicy[] {
   return clone(policies);
 }

--- a/src/webapp/plugins/mcp-governance/migrations/001_mcp_governance.sql
+++ b/src/webapp/plugins/mcp-governance/migrations/001_mcp_governance.sql
@@ -23,6 +23,32 @@ CREATE TABLE IF NOT EXISTS mcp_server_registry (
   updated_at TEXT DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS agent_server_policy (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  server_id TEXT NOT NULL,
+  permission TEXT NOT NULL,
+  env_scope TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')),
+  UNIQUE (agent_id, server_id, env_scope)
+);
+
+CREATE TABLE IF NOT EXISTS agent_tool_policy (
+  id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  server_id TEXT NOT NULL,
+  tool_id TEXT NOT NULL,
+  override_mode TEXT NOT NULL,
+  permission TEXT,
+  approval_required INTEGER NOT NULL DEFAULT 0,
+  blocked INTEGER NOT NULL DEFAULT 0,
+  env_scope TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now')),
+  UNIQUE (agent_id, server_id, tool_id, env_scope)
+);
+
 CREATE TABLE IF NOT EXISTS mcp_migrations (
   id TEXT PRIMARY KEY,
   applied_at TEXT DEFAULT (datetime('now'))

--- a/src/webapp/plugins/mcp-governance/service.ts
+++ b/src/webapp/plugins/mcp-governance/service.ts
@@ -10,12 +10,19 @@ import {
   DEFAULT_ENVIRONMENT_POLICIES,
   DEFAULT_POLICIES,
   DEFAULT_SERVERS,
+  DEFAULT_TOOL_POLICIES,
 } from './defaults';
 import type {
+  AgentToolPolicy,
   AgentServerPolicy,
   AgentType,
+  EnvironmentPolicy,
+  EnvironmentScope,
   McpServerRegistry,
   McpSyncResult,
+  PermissionLevel,
+  ResolvedServerPermission,
+  ResolvedToolPermission,
   RuntimeManifest,
 } from './types';
 
@@ -33,6 +40,17 @@ export interface RuntimeBuildResult {
 export interface InitResult {
   created: string[];
   skipped: string[];
+}
+
+export class EnvScopeValidationError extends Error {
+  readonly code = 'INVALID_ENV_SCOPE';
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode = 400) {
+    super(message);
+    this.name = 'EnvScopeValidationError';
+    this.statusCode = statusCode;
+  }
 }
 
 function stableStringify(value: unknown): string {
@@ -57,6 +75,8 @@ export class McpGovernanceService {
   private readonly _stateDir: string;
   private readonly _agentsFile: string;
   private readonly _serversFile: string;
+  private readonly _serverPoliciesFile: string;
+  private readonly _toolPoliciesFile: string;
 
   constructor(opts?: { projectRoot?: string; storageProvider?: StorageProvider | null }) {
     this.projectRoot = opts?.projectRoot || path.resolve(__dirname, '../../../..');
@@ -73,6 +93,8 @@ export class McpGovernanceService {
     this._stateDir = path.join(this.projectRoot, '.agentic', 'mcp-governance');
     this._agentsFile = path.join(this._stateDir, 'agent-types.json');
     this._serversFile = path.join(this._stateDir, 'mcp-servers.json');
+    this._serverPoliciesFile = path.join(this._stateDir, 'agent-server-policies.json');
+    this._toolPoliciesFile = path.join(this._stateDir, 'agent-tool-policies.json');
   }
 
   private async _readJsonFile<T>(filePath: string, fallback: T): Promise<T> {
@@ -99,6 +121,7 @@ export class McpGovernanceService {
       { name: 'agents.json', payload: DEFAULT_AGENTS },
       { name: 'servers.json', payload: DEFAULT_SERVERS },
       { name: 'policies.json', payload: DEFAULT_POLICIES },
+      { name: 'tool-policies.json', payload: DEFAULT_TOOL_POLICIES },
       { name: 'environment-policies.json', payload: DEFAULT_ENVIRONMENT_POLICIES },
     ];
 
@@ -168,6 +191,17 @@ export class McpGovernanceService {
     return this._readConfig<AgentServerPolicy[]>('policies.json', DEFAULT_POLICIES);
   }
 
+  async getDefinedToolPolicies(): Promise<AgentToolPolicy[]> {
+    return this._readConfig<AgentToolPolicy[]>('tool-policies.json', DEFAULT_TOOL_POLICIES);
+  }
+
+  async getDefinedEnvironmentPolicies(): Promise<EnvironmentPolicy[]> {
+    return this._readConfig<EnvironmentPolicy[]>(
+      'environment-policies.json',
+      DEFAULT_ENVIRONMENT_POLICIES
+    );
+  }
+
   async listAgents(): Promise<AgentType[]> {
     if (this._storageProvider) {
       return (await this._storageProvider.list('mcp_agent_types')) as unknown as AgentType[];
@@ -182,6 +216,24 @@ export class McpGovernanceService {
       )) as unknown as McpServerRegistry[];
     }
     return this._readJsonFile<McpServerRegistry[]>(this._serversFile, []);
+  }
+
+  async listServerPolicies(): Promise<AgentServerPolicy[]> {
+    if (this._storageProvider) {
+      return (await this._storageProvider.list(
+        'mcp_agent_server_policy'
+      )) as unknown as AgentServerPolicy[];
+    }
+    return this._readJsonFile<AgentServerPolicy[]>(this._serverPoliciesFile, []);
+  }
+
+  async listToolPolicies(): Promise<AgentToolPolicy[]> {
+    if (this._storageProvider) {
+      return (await this._storageProvider.list(
+        'mcp_agent_tool_policy'
+      )) as unknown as AgentToolPolicy[];
+    }
+    return this._readJsonFile<AgentToolPolicy[]>(this._toolPoliciesFile, []);
   }
 
   private async _writeAgents(rows: AgentType[]): Promise<void> {
@@ -210,6 +262,50 @@ export class McpGovernanceService {
       return;
     }
     await this._writeJsonFile(this._serversFile, rows);
+  }
+
+  private _serverPolicyKey(row: AgentServerPolicy): string {
+    return `${row.agentId}:${row.serverId}:${row.envScope || '*'}`;
+  }
+
+  private _serverPolicyId(row: AgentServerPolicy): string {
+    return encodeURIComponent(this._serverPolicyKey(row)).replace(/\*/g, '%2A');
+  }
+
+  private _toolPolicyKey(row: AgentToolPolicy): string {
+    return `${row.agentId}:${row.serverId}:${row.toolId}:${row.envScope || '*'}`;
+  }
+
+  private _toolPolicyId(row: AgentToolPolicy): string {
+    return encodeURIComponent(this._toolPolicyKey(row)).replace(/\*/g, '%2A');
+  }
+
+  private async _writeServerPolicies(rows: AgentServerPolicy[]): Promise<void> {
+    if (this._storageProvider) {
+      const ops = rows.map((row) => ({
+        type: 'write' as const,
+        collection: 'mcp_agent_server_policy',
+        id: this._serverPolicyId(row),
+        data: { ...row, id: this._serverPolicyId(row) },
+      }));
+      await this._storageProvider.transaction(ops);
+      return;
+    }
+    await this._writeJsonFile(this._serverPoliciesFile, rows);
+  }
+
+  private async _writeToolPolicies(rows: AgentToolPolicy[]): Promise<void> {
+    if (this._storageProvider) {
+      const ops = rows.map((row) => ({
+        type: 'write' as const,
+        collection: 'mcp_agent_tool_policy',
+        id: this._toolPolicyId(row),
+        data: { ...row, id: this._toolPolicyId(row) },
+      }));
+      await this._storageProvider.transaction(ops);
+      return;
+    }
+    await this._writeJsonFile(this._toolPoliciesFile, rows);
   }
 
   async syncAgents(nextAgents: AgentType[], opts?: SyncOptions): Promise<McpSyncResult> {
@@ -270,6 +366,68 @@ export class McpGovernanceService {
     return { added, updated, unchanged };
   }
 
+  async syncServerPolicies(
+    nextPolicies: AgentServerPolicy[],
+    opts?: SyncOptions
+  ): Promise<McpSyncResult> {
+    const current = await this.listServerPolicies();
+    const currentMap = new Map(current.map((p) => [this._serverPolicyKey(p), p]));
+
+    let added = 0;
+    let updated = 0;
+    let unchanged = 0;
+
+    for (const policy of nextPolicies) {
+      const key = this._serverPolicyKey(policy);
+      const existing = currentMap.get(key);
+      if (!existing) {
+        added += 1;
+      } else if (!isEqual(existing, policy)) {
+        updated += 1;
+      } else {
+        unchanged += 1;
+      }
+      currentMap.set(key, policy);
+    }
+
+    if (!opts?.dryRun) {
+      await this._writeServerPolicies(Array.from(currentMap.values()));
+    }
+
+    return { added, updated, unchanged };
+  }
+
+  async syncToolPolicies(
+    nextPolicies: AgentToolPolicy[],
+    opts?: SyncOptions
+  ): Promise<McpSyncResult> {
+    const current = await this.listToolPolicies();
+    const currentMap = new Map(current.map((p) => [this._toolPolicyKey(p), p]));
+
+    let added = 0;
+    let updated = 0;
+    let unchanged = 0;
+
+    for (const policy of nextPolicies) {
+      const key = this._toolPolicyKey(policy);
+      const existing = currentMap.get(key);
+      if (!existing) {
+        added += 1;
+      } else if (!isEqual(existing, policy)) {
+        updated += 1;
+      } else {
+        unchanged += 1;
+      }
+      currentMap.set(key, policy);
+    }
+
+    if (!opts?.dryRun) {
+      await this._writeToolPolicies(Array.from(currentMap.values()));
+    }
+
+    return { added, updated, unchanged };
+  }
+
   async recordServerHealth(
     serverId: string,
     isHealthy: boolean,
@@ -296,25 +454,154 @@ export class McpGovernanceService {
     return server;
   }
 
-  private _resolvePermission(
+  private _isWriteLike(level: PermissionLevel): boolean {
+    return level === 'W' || level === 'A';
+  }
+
+  validateEnvironmentScope(envScope: string | undefined, expectedScope?: string): EnvironmentScope {
+    if (!envScope || envScope.trim() === '') {
+      throw new EnvScopeValidationError('env_scope is required', 400);
+    }
+    if (envScope !== 'dev' && envScope !== 'test' && envScope !== 'prod') {
+      throw new EnvScopeValidationError(`Invalid env_scope '${envScope}'`, 403);
+    }
+    if (expectedScope && envScope !== expectedScope) {
+      throw new EnvScopeValidationError(
+        `env_scope '${envScope}' is not allowed for this deployment context`,
+        403
+      );
+    }
+    return envScope;
+  }
+
+  private _resolveServerPermissionInternal(
     agentId: string,
     serverId: string,
-    policies: AgentServerPolicy[]
-  ): { level: string; approvalRequired: boolean; blocked: boolean } {
-    const match = policies.find((p) => p.agentId === agentId && p.serverId === serverId);
-    const level = match?.permission || 'N';
+    environment: EnvironmentScope,
+    policies: AgentServerPolicy[],
+    envPolicies: EnvironmentPolicy[]
+  ): ResolvedServerPermission {
+    const envPolicy = envPolicies.find((p) => p.env === environment);
+    const scoped = policies.find(
+      (p) => p.agentId === agentId && p.serverId === serverId && p.envScope === environment
+    );
+    const unscoped = policies.find(
+      (p) => p.agentId === agentId && p.serverId === serverId && !p.envScope
+    );
+    const match = scoped || unscoped;
+
+    const level = match?.permission || envPolicy?.defaultPermission || ('N' as PermissionLevel);
+    const source: ResolvedServerPermission['source'] = match
+      ? 'server-policy'
+      : envPolicy
+        ? 'environment-default'
+        : 'implicit-deny';
+    const approvalRequired =
+      level === 'A' || (!!envPolicy?.writeRequiresApproval && this._isWriteLike(level));
+
     return {
-      level,
-      approvalRequired: level === 'A',
+      agentId,
+      serverId,
+      environment,
+      permissionLevel: level,
+      approvalRequired,
       blocked: level === 'X' || level === 'N',
+      source,
+    };
+  }
+
+  async resolveServerPermission(
+    agentId: string,
+    serverId: string,
+    environment: EnvironmentScope
+  ): Promise<ResolvedServerPermission> {
+    const [policies, envPolicies] = await Promise.all([
+      this.getDefinedPolicies(),
+      this.getDefinedEnvironmentPolicies(),
+    ]);
+    return this._resolveServerPermissionInternal(
+      agentId,
+      serverId,
+      environment,
+      policies,
+      envPolicies
+    );
+  }
+
+  async resolveToolPermission(
+    agentId: string,
+    serverId: string,
+    toolId: string,
+    environment: EnvironmentScope
+  ): Promise<ResolvedToolPermission> {
+    const [serverPolicies, envPolicies, toolPolicies] = await Promise.all([
+      this.getDefinedPolicies(),
+      this.getDefinedEnvironmentPolicies(),
+      this.getDefinedToolPolicies(),
+    ]);
+
+    const base = this._resolveServerPermissionInternal(
+      agentId,
+      serverId,
+      environment,
+      serverPolicies,
+      envPolicies
+    );
+
+    const toolPolicy = toolPolicies.find(
+      (p) =>
+        p.agentId === agentId &&
+        p.serverId === serverId &&
+        p.toolId === toolId &&
+        (p.envScope === environment || !p.envScope)
+    );
+
+    if (!toolPolicy) {
+      return {
+        ...base,
+        toolId,
+        source: base.source,
+      };
+    }
+
+    let permissionLevel = base.permissionLevel;
+    let blocked = base.blocked;
+    if (toolPolicy.overrideMode === 'deny') {
+      permissionLevel = 'X';
+      blocked = true;
+    } else if (toolPolicy.overrideMode === 'set' && toolPolicy.permission) {
+      permissionLevel = toolPolicy.permission;
+      blocked = permissionLevel === 'X' || permissionLevel === 'N';
+    }
+
+    if (toolPolicy.blocked === true) {
+      blocked = true;
+    }
+
+    const envPolicy = envPolicies.find((p) => p.env === environment);
+    const approvalRequired =
+      toolPolicy.approvalRequired === true ||
+      permissionLevel === 'A' ||
+      (!!envPolicy?.writeRequiresApproval && this._isWriteLike(permissionLevel));
+
+    return {
+      agentId,
+      serverId,
+      toolId,
+      environment,
+      permissionLevel,
+      approvalRequired,
+      blocked,
+      source: 'tool-override',
     };
   }
 
   async buildRuntimeArtifacts(): Promise<RuntimeBuildResult> {
-    const [agents, servers, policies] = await Promise.all([
+    const [agents, servers, policies, envPolicies] = await Promise.all([
       this.listAgents(),
       this.listServers(),
       this.getDefinedPolicies(),
+      this.getDefinedEnvironmentPolicies(),
     ]);
 
     const runtimeDir = path.join(this.generatedDir, 'runtime-manifests');
@@ -333,11 +620,21 @@ export class McpGovernanceService {
 
     let manifestCount = 0;
     for (const agent of agents) {
+      const environment: EnvironmentScope =
+        process.env.ENV_SCOPE === 'prod' || process.env.ENV_SCOPE === 'test'
+          ? (process.env.ENV_SCOPE as EnvironmentScope)
+          : 'dev';
       const manifest: RuntimeManifest = {
         agentId: agent.id,
         generatedAt: new Date().toISOString(),
         servers: servers.map((server) => {
-          const resolved = this._resolvePermission(agent.id, server.id, policies);
+          const resolved = this._resolveServerPermissionInternal(
+            agent.id,
+            server.id,
+            environment,
+            policies,
+            envPolicies
+          );
           return {
             serverId: server.id,
             endpoint: server.endpoint,
@@ -346,8 +643,7 @@ export class McpGovernanceService {
             tools: [
               {
                 toolId: `${server.id}.default`,
-                permissionLevel:
-                  resolved.level as RuntimeManifest['servers'][number]['tools'][number]['permissionLevel'],
+                permissionLevel: resolved.permissionLevel,
                 approvalRequired: resolved.approvalRequired,
                 blocked: resolved.blocked,
               },

--- a/src/webapp/plugins/mcp-governance/types.ts
+++ b/src/webapp/plugins/mcp-governance/types.ts
@@ -45,16 +45,53 @@ export interface McpServerRegistry {
 
 export type PermissionLevel = 'N' | 'D' | 'R' | 'P' | 'W' | 'A' | 'X';
 
+export type EnvironmentScope = 'dev' | 'test' | 'prod';
+
 export interface AgentServerPolicy {
   agentId: string;
   serverId: string;
   permission: PermissionLevel;
+  envScope?: EnvironmentScope | null;
 }
 
 export interface EnvironmentPolicy {
-  env: 'dev' | 'test' | 'prod';
+  env: EnvironmentScope;
   defaultPermission: PermissionLevel;
   writeRequiresApproval: boolean;
+}
+
+export type ToolOverrideMode = 'inherit' | 'set' | 'deny';
+
+export interface AgentToolPolicy {
+  agentId: string;
+  serverId: string;
+  toolId: string;
+  overrideMode: ToolOverrideMode;
+  permission?: PermissionLevel;
+  approvalRequired?: boolean;
+  blocked?: boolean;
+  envScope?: EnvironmentScope | null;
+}
+
+export interface ResolvedServerPermission {
+  agentId: string;
+  serverId: string;
+  environment: EnvironmentScope;
+  permissionLevel: PermissionLevel;
+  approvalRequired: boolean;
+  blocked: boolean;
+  source: 'server-policy' | 'environment-default' | 'implicit-deny';
+}
+
+export interface ResolvedToolPermission {
+  agentId: string;
+  serverId: string;
+  toolId: string;
+  environment: EnvironmentScope;
+  permissionLevel: PermissionLevel;
+  approvalRequired: boolean;
+  blocked: boolean;
+  source: 'server-policy' | 'environment-default' | 'tool-override' | 'implicit-deny';
 }
 
 export interface RuntimeToolPermission {

--- a/src/webapp/routes/mcp.ts
+++ b/src/webapp/routes/mcp.ts
@@ -3,7 +3,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { ServerContext } from '../context';
 import { errorResponse } from '../utils/errors';
-import { McpGovernanceService } from '../plugins/mcp-governance';
+import { EnvScopeValidationError, McpGovernanceService } from '../plugins/mcp-governance';
 
 function ensureOperatorOrAdmin(
   request: FastifyRequest,
@@ -43,5 +43,68 @@ export async function registerRoutes(app: FastifyInstance, ctx: ServerContext): 
     if (!ensureOperatorOrAdmin(request, reply, ctx)) return;
     const servers = await svc.listServers();
     return reply.send({ ok: true, count: servers.length, servers });
+  });
+
+  app.get('/api/v1/mcp/policies', { schema: { tags: ['mcp'] } }, async (request, reply) => {
+    if (!ensureOperatorOrAdmin(request, reply, ctx)) return;
+    const policies = await svc.getDefinedPolicies();
+    return reply.send({ ok: true, count: policies.length, policies });
+  });
+
+  app.post('/api/v1/mcp/resolve/server', { schema: { tags: ['mcp'] } }, async (request, reply) => {
+    if (!ensureOperatorOrAdmin(request, reply, ctx)) return;
+    const body = (request.body || {}) as Record<string, unknown>;
+    const agentId = String(body.agent_id || '');
+    const serverId = String(body.server_id || '');
+
+    if (!agentId || !serverId) {
+      return reply
+        .code(400)
+        .send(errorResponse('INVALID_REQUEST', 'agent_id and server_id are required'));
+    }
+
+    try {
+      const expectedScope =
+        process.env.ENV_SCOPE === 'test' || process.env.ENV_SCOPE === 'prod'
+          ? process.env.ENV_SCOPE
+          : 'dev';
+      const environment = svc.validateEnvironmentScope(String(body.env_scope || ''), expectedScope);
+      const resolved = await svc.resolveServerPermission(agentId, serverId, environment);
+      return reply.send({ ok: true, resolved });
+    } catch (error) {
+      if (error instanceof EnvScopeValidationError) {
+        return reply.code(error.statusCode).send(errorResponse(error.code, error.message));
+      }
+      throw error;
+    }
+  });
+
+  app.post('/api/v1/mcp/resolve/tool', { schema: { tags: ['mcp'] } }, async (request, reply) => {
+    if (!ensureOperatorOrAdmin(request, reply, ctx)) return;
+    const body = (request.body || {}) as Record<string, unknown>;
+    const agentId = String(body.agent_id || '');
+    const serverId = String(body.server_id || '');
+    const toolId = String(body.tool_id || '');
+
+    if (!agentId || !serverId || !toolId) {
+      return reply
+        .code(400)
+        .send(errorResponse('INVALID_REQUEST', 'agent_id, server_id and tool_id are required'));
+    }
+
+    try {
+      const expectedScope =
+        process.env.ENV_SCOPE === 'test' || process.env.ENV_SCOPE === 'prod'
+          ? process.env.ENV_SCOPE
+          : 'dev';
+      const environment = svc.validateEnvironmentScope(String(body.env_scope || ''), expectedScope);
+      const resolved = await svc.resolveToolPermission(agentId, serverId, toolId, environment);
+      return reply.send({ ok: true, resolved });
+    } catch (error) {
+      if (error instanceof EnvScopeValidationError) {
+        return reply.code(error.statusCode).send(errorResponse(error.code, error.message));
+      }
+      throw error;
+    }
   });
 }

--- a/tests/unit/agent-runtime-adapter.test.js
+++ b/tests/unit/agent-runtime-adapter.test.js
@@ -868,6 +868,100 @@ describe('ProviderBackedLlmRuntimeAdapter', () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it('blocks tool execution when resolved runtime manifest permission is blocked', async () => {
+    const contractPath = await writeContractFixture(
+      'tool-runtime-permission-block-contract.md',
+      ['# Contract', '', '```markdown', '## Metadata', '## HANDOFF CHECKLIST', '```'].join('\n')
+    );
+    const skillPath = await writeSkillFixture(
+      'tool-runtime-permission-block-skill.md',
+      contractPath
+    );
+
+    const runtimeManifestDir = path.join(tmpRoot, 'runtime-manifests');
+    await fs.mkdir(runtimeManifestDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runtimeManifestDir, `${AGENT.id}.json`),
+      JSON.stringify(
+        {
+          agentId: AGENT.id,
+          generatedAt: new Date().toISOString(),
+          servers: [
+            {
+              serverId: 'git',
+              tools: [
+                {
+                  toolId: 'git.status',
+                  permissionLevel: 'X',
+                  approvalRequired: false,
+                  blocked: true,
+                },
+              ],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    const complete = vi.fn().mockResolvedValue({
+      content: '',
+      model: 'gpt-test',
+      usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+      finishReason: 'tool_calls',
+      toolCalls: [
+        {
+          id: 'tc-runtime-perm-1',
+          name: 'tool.git.commit',
+          arguments: {
+            target: 'git',
+            operation: 'status',
+            params: {},
+          },
+        },
+      ],
+    });
+
+    const providerRegistry = {
+      getProvider: vi.fn().mockReturnValue({
+        providerName: 'openai',
+        capabilities: {},
+        complete,
+      }),
+    };
+
+    const execute = vi.fn();
+    const adapter = new ProviderBackedLlmRuntimeAdapter({
+      name: 'llm-openai-runtime-permission-block',
+      providerName: 'openai',
+      outputDir: tmpRoot,
+      providerRegistry,
+      toolExecutor: { execute },
+      runtimeManifestDir,
+      validationMaxRetries: 0,
+    });
+
+    await expect(
+      adapter.invoke(AGENT, PLATFORM, {
+        skillFile: skillPath,
+        predecessorOutputs: {},
+        questionnaireInput: null,
+        role: 'admin',
+        profile: 'production-distributed',
+        sessionState: {
+          mode: 'AUDIT',
+          policyApprovals: {
+            'tool.git.commit': true,
+          },
+        },
+      })
+    ).rejects.toThrow(/TOOL_POLICY_BLOCKED|blocked by resolved permissions/);
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('sanitizes untrusted context and emits trust metadata before model invocation', async () => {
     const contractPath = await writeContractFixture(
       'context-trust-contract.md',

--- a/tests/unit/mcp-governance-cli.test.js
+++ b/tests/unit/mcp-governance-cli.test.js
@@ -66,6 +66,8 @@ describe('run() CLI commands', () => {
       path.join(pluginRoot, 'migrations', '001_mcp_governance.sql'),
       [
         'CREATE TABLE IF NOT EXISTS agent_types (id TEXT PRIMARY KEY, category TEXT NOT NULL, control_posture TEXT NOT NULL, requires_workload_identity INTEGER NOT NULL, app_registration_ref TEXT, template_category TEXT NOT NULL);',
+        'CREATE TABLE IF NOT EXISTS agent_server_policy (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, server_id TEXT NOT NULL, permission TEXT NOT NULL, env_scope TEXT);',
+        'CREATE TABLE IF NOT EXISTS agent_tool_policy (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, server_id TEXT NOT NULL, tool_id TEXT NOT NULL, override_mode TEXT NOT NULL, permission TEXT, approval_required INTEGER NOT NULL DEFAULT 0, blocked INTEGER NOT NULL DEFAULT 0, env_scope TEXT);',
         "CREATE TABLE IF NOT EXISTS mcp_migrations (id TEXT PRIMARY KEY, applied_at TEXT DEFAULT (datetime('now')));",
       ].join('\n'),
       'utf8'
@@ -213,6 +215,24 @@ describe('run() CLI commands', () => {
     await run(root);
     const result = parsedOut();
     expect(result.apply).toBe(true);
+  });
+
+  it('policies sync --apply seeds server policies', async () => {
+    process.argv = argv('policies', 'sync', '--apply');
+    await run(root);
+    const result = parsedOut();
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe('policies sync');
+    expect(result.added).toBeGreaterThan(0);
+  });
+
+  it('tool-policies sync --apply seeds tool policies', async () => {
+    process.argv = argv('tool-policies', 'sync', '--apply');
+    await run(root);
+    const result = parsedOut();
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe('tool-policies sync');
+    expect(result.added).toBeGreaterThan(0);
   });
 
   // ── runtime build ─────────────────────────────────────────────────────────────

--- a/tests/unit/mcp-governance-factories.test.js
+++ b/tests/unit/mcp-governance-factories.test.js
@@ -5,6 +5,7 @@ const {
   defineMcpServers,
   definePolicies,
   defineEnvironmentPolicies,
+  defineToolPolicies,
 } = require('../../src/webapp/plugins/mcp-governance/factories');
 
 describe('mcp-governance factories', () => {
@@ -46,10 +47,21 @@ describe('mcp-governance factories', () => {
       { env: 'dev', defaultPermission: 'W', writeRequiresApproval: false },
     ]);
 
+    const toolPolicies = defineToolPolicies([
+      {
+        agentId: 'orchestrator',
+        serverId: 'workspace-management',
+        toolId: 'workspace-management.default',
+        overrideMode: 'set',
+        permission: 'R',
+      },
+    ]);
+
     expect(agents).toHaveLength(1);
     expect(servers).toHaveLength(1);
     expect(policies).toHaveLength(1);
     expect(envPolicies).toHaveLength(1);
+    expect(toolPolicies).toHaveLength(1);
   });
 
   it('returns cloned arrays so callers cannot mutate source objects', () => {

--- a/tests/unit/mcp-governance-service.test.js
+++ b/tests/unit/mcp-governance-service.test.js
@@ -17,6 +17,8 @@ describe('McpGovernanceService', () => {
       path.join(pluginRoot, 'migrations', '001_mcp_governance.sql'),
       [
         'CREATE TABLE IF NOT EXISTS agent_types (id TEXT PRIMARY KEY, category TEXT NOT NULL, control_posture TEXT NOT NULL, requires_workload_identity INTEGER NOT NULL, app_registration_ref TEXT, template_category TEXT NOT NULL);',
+        'CREATE TABLE IF NOT EXISTS agent_server_policy (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, server_id TEXT NOT NULL, permission TEXT NOT NULL, env_scope TEXT);',
+        'CREATE TABLE IF NOT EXISTS agent_tool_policy (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, server_id TEXT NOT NULL, tool_id TEXT NOT NULL, override_mode TEXT NOT NULL, permission TEXT, approval_required INTEGER NOT NULL DEFAULT 0, blocked INTEGER NOT NULL DEFAULT 0, env_scope TEXT);',
         "CREATE TABLE IF NOT EXISTS mcp_migrations (id TEXT PRIMARY KEY, applied_at TEXT DEFAULT (datetime('now')));",
       ].join('\n'),
       'utf8'
@@ -79,5 +81,40 @@ describe('McpGovernanceService', () => {
 
     const stored = await svc.listServers();
     expect(stored).toEqual([]);
+  });
+
+  it('resolves server and tool permissions with environment scope', async () => {
+    const server = await svc.resolveServerPermission('orchestrator', 'workspace-management', 'dev');
+    expect(server.permissionLevel).toBe('R');
+    expect(server.blocked).toBe(false);
+
+    const tool = await svc.resolveToolPermission(
+      'documentation',
+      'workspace-management',
+      'workspace-management.delete_workspace',
+      'dev'
+    );
+    expect(tool.permissionLevel).toBe('X');
+    expect(tool.blocked).toBe(true);
+  });
+
+  it('validates env_scope and rejects missing or invalid values', () => {
+    expect(() => svc.validateEnvironmentScope(undefined)).toThrow(/env_scope is required/i);
+    expect(() => svc.validateEnvironmentScope('staging')).toThrow(/Invalid env_scope/i);
+    expect(() => svc.validateEnvironmentScope('prod', 'dev')).toThrow(/not allowed/i);
+    expect(svc.validateEnvironmentScope('dev', 'dev')).toBe('dev');
+  });
+
+  it('syncs server and tool policies in dry-run mode without writing state', async () => {
+    const serverPolicies = await svc.getDefinedPolicies();
+    const toolPolicies = await svc.getDefinedToolPolicies();
+
+    const serverDry = await svc.syncServerPolicies(serverPolicies, { dryRun: true });
+    const toolDry = await svc.syncToolPolicies(toolPolicies, { dryRun: true });
+
+    expect(serverDry.added).toBeGreaterThan(0);
+    expect(toolDry.added).toBeGreaterThan(0);
+    expect(await svc.listServerPolicies()).toEqual([]);
+    expect(await svc.listToolPolicies()).toEqual([]);
   });
 });

--- a/tests/unit/routes-mcp.test.js
+++ b/tests/unit/routes-mcp.test.js
@@ -63,6 +63,9 @@ describe('routes/mcp', () => {
     const routes = createRoutes();
     expect(routes).toHaveProperty('GET /api/v1/mcp/agents');
     expect(routes).toHaveProperty('GET /api/v1/mcp/servers');
+    expect(routes).toHaveProperty('GET /api/v1/mcp/policies');
+    expect(routes).toHaveProperty('POST /api/v1/mcp/resolve/server');
+    expect(routes).toHaveProperty('POST /api/v1/mcp/resolve/tool');
   });
 
   it('returns catalog and registry payloads', async () => {
@@ -82,6 +85,59 @@ describe('routes/mcp', () => {
     await routes['GET /api/v1/mcp/servers'](createReq('/api/v1/mcp/servers'), serversRes);
     expect(serversRes.statusCode).toBe(200);
     expect(parsed(serversRes).count).toBe(0);
+
+    vi.spyOn(McpGovernanceService.prototype, 'getDefinedPolicies').mockResolvedValue([]);
+    const policiesRes = createRes();
+    await routes['GET /api/v1/mcp/policies'](createReq('/api/v1/mcp/policies'), policiesRes);
+    expect(policiesRes.statusCode).toBe(200);
+    expect(parsed(policiesRes).count).toBe(0);
+  });
+
+  it('returns 400 when env_scope is missing and resolves when valid', async () => {
+    const routes = createRoutes();
+
+    const missingRes = createRes();
+    await routes['POST /api/v1/mcp/resolve/server'](
+      createReq('/api/v1/mcp/resolve/server', 'POST', {
+        agent_id: 'orchestrator',
+        server_id: 'workspace-management',
+      }),
+      missingRes
+    );
+    expect(missingRes.statusCode).toBe(400);
+
+    vi.spyOn(McpGovernanceService.prototype, 'resolveServerPermission').mockResolvedValue({
+      permissionLevel: 'R',
+      approvalRequired: false,
+      blocked: false,
+    });
+
+    const okRes = createRes();
+    await routes['POST /api/v1/mcp/resolve/server'](
+      createReq('/api/v1/mcp/resolve/server', 'POST', {
+        agent_id: 'orchestrator',
+        server_id: 'workspace-management',
+        env_scope: 'dev',
+      }),
+      okRes
+    );
+    expect(okRes.statusCode).toBe(200);
+    expect(parsed(okRes).ok).toBe(true);
+  });
+
+  it('returns 403 for invalid env_scope on tool resolve', async () => {
+    const routes = createRoutes();
+    const res = createRes();
+    await routes['POST /api/v1/mcp/resolve/tool'](
+      createReq('/api/v1/mcp/resolve/tool', 'POST', {
+        agent_id: 'orchestrator',
+        server_id: 'workspace-management',
+        tool_id: 'workspace-management.default',
+        env_scope: 'staging',
+      }),
+      res
+    );
+    expect(res.statusCode).toBe(403);
   });
 
   it('enforces operator/admin role when auth middleware is active', async () => {


### PR DESCRIPTION
## Summary\n- integrate resolved MCP runtime permissions into the actual tool execution middleware path\n- pass agent/environment context from runtime adapter to middleware enforcement\n- enforce runtime-manifest permission blocks before adapter execution\n- add/extend governance service, routes, CLI, migrations, and unit tests for policy plane support\n\n## Validation\n- npm run format\n- npm run lint\n- npm run test:coverage\n- targeted unit/integration tests for runtime adapter + governance enforcement\n\n## Notes\n- generated telemetry/history artifacts were intentionally left out of the enforcement commit\n