### PR TITLE
feat: implement P2 wave for #1100 #1097 #1091 #1106 #1103 #1093

### DIFF
--- a/platform/engine/cli.ts
+++ b/platform/engine/cli.ts
@@ -32,6 +32,7 @@
 
 import { createEngine } from './engine';
 import { MODE_CONFIGS as _MODE_CONFIGS } from './state-machine';
+import { assertRuntimeSchemaParity, PHASE_AGENTS } from './dispatcher';
 
 // ─── Argument Parser ─────────────────────────────────────────
 
@@ -62,6 +63,7 @@ interface ParsedArgs {
   project: string | null;
   platform: string;
   resume: boolean;
+  dryRun: boolean;
   interactive: boolean;
   singleStep: boolean;
   checkpoint: boolean;
@@ -92,6 +94,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     project: null,
     platform: 'copilot',
     resume: false,
+    dryRun: false,
     interactive: false,
     singleStep: false,
     checkpoint: false,
@@ -112,6 +115,11 @@ function parseArgs(argv: string[]): ParsedArgs {
 
     if (arg === '--resume') {
       result.resume = true;
+      continue;
+    }
+
+    if (arg === '--dry-run') {
+      result.dryRun = true;
       continue;
     }
 
@@ -241,6 +249,7 @@ Commands:
 Options:
   --platform <name>   AI platform: copilot | claude | codex  (default: copilot)
   --resume            Resume from the last saved session state
+  --dry-run           Validate command/runtime config without executing transitions
   --interactive       Enable interactive mode (prompt at gate boundaries)
   --reason <text>     Reason for approval/rejection decision
   --single-step       Process one state transition and exit
@@ -266,6 +275,85 @@ function executeCommand(
   deps: { write?: (msg: string) => unknown; promptFn?: (...args: unknown[]) => unknown } = {}
 ) {
   const write = deps.write || ((msg: string) => process.stdout.write(msg));
+
+  function runDryRunValidation() {
+    if (!parsed.command) {
+      return {
+        ok: false,
+        valid: false,
+        errors: ['No command specified'],
+        checks: [],
+      };
+    }
+
+    const checks: Array<{ name: string; passed: boolean; detail: string }> = [];
+    const errors: string[] = [];
+
+    const isMetaCommand = parsed.command.startsWith('_');
+    checks.push({
+      name: 'command',
+      passed: true,
+      detail: isMetaCommand ? 'Meta command dry-run validated' : `Mode command ${parsed.command}`,
+    });
+
+    if (!isMetaCommand) {
+      const modeExists = Object.prototype.hasOwnProperty.call(_MODE_CONFIGS, parsed.command);
+      checks.push({
+        name: 'mode-config',
+        passed: modeExists,
+        detail: modeExists
+          ? 'Mode exists in MODE_CONFIGS'
+          : `Mode ${parsed.command} missing from MODE_CONFIGS`,
+      });
+      if (!modeExists) {
+        errors.push(`Mode ${parsed.command} is not configured`);
+      }
+
+      try {
+        assertRuntimeSchemaParity(PHASE_AGENTS);
+        checks.push({
+          name: 'dispatcher-schema-parity',
+          passed: true,
+          detail: 'Runtime dispatcher phase-agent map matches canonical schema',
+        });
+      } catch (err) {
+        const message = (err as Error).message;
+        checks.push({
+          name: 'dispatcher-schema-parity',
+          passed: false,
+          detail: message,
+        });
+        errors.push(message);
+      }
+    }
+
+    const platformValid = VALID_PLATFORMS.includes(parsed.platform);
+    checks.push({
+      name: 'platform',
+      passed: platformValid,
+      detail: platformValid ? `Platform ${parsed.platform} is supported` : 'Invalid platform',
+    });
+    if (!platformValid) {
+      errors.push(`Invalid platform ${parsed.platform}`);
+    }
+
+    return {
+      ok: errors.length === 0,
+      valid: errors.length === 0,
+      dryRun: true,
+      command: parsed.command,
+      platform: parsed.platform,
+      project: parsed.project,
+      checks,
+      errors,
+    };
+  }
+
+  if (parsed.dryRun) {
+    const validation = runDryRunValidation();
+    write(JSON.stringify(validation, null, 2) + '\n');
+    return validation;
+  }
 
   if (parsed.command === '_STATUS') {
     const st = engine.status();

--- a/platform/sdlc/adapters/llm-adapter.ts
+++ b/platform/sdlc/adapters/llm-adapter.ts
@@ -7,7 +7,7 @@
  * documentation generation, architecture analysis, test generation.
  *
  * Supports multiple providers (OpenAI, Azure OpenAI, Anthropic) via a
- * unified HTTP interface using curl (no SDK dependency). Includes token
+ * unified HTTP interface using native fetch/undici (no SDK dependency). Includes token
  * budget enforcement and rate-limit retry with exponential backoff.
  *
  * API keys are sourced from environment variables only — never from config.
@@ -175,35 +175,56 @@ function resolveProvider(config: LlmConfig): ProviderEndpoint | null {
   }
 }
 
-// ─── HTTP call via curl ──────────────────────────────────────
+// ─── HTTP call via fetch (undici runtime) ────────────────────
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  }
+) => Promise<{
+  status: number;
+  text(): Promise<string>;
+}>;
 
 async function httpPost(
   url: string,
   headers: Record<string, string>,
   body: Record<string, unknown>,
   timeout: number,
-  exec: typeof shellExec = shellExec
+  fetchImpl: FetchLike
 ): Promise<{ status: number; body: unknown }> {
-  const args = ['-s', '-w', '\n%{http_code}', '-X', 'POST'];
-  for (const [k, v] of Object.entries(headers)) {
-    args.push('-H', `${k}: ${v}`);
-  }
-  args.push('-d', JSON.stringify(body));
-  args.push(url);
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeout);
 
-  const result = await exec('curl', args, { timeout });
-  const lines = result.stdout.trimEnd().split('\n');
-  const statusCode = parseInt(lines[lines.length - 1], 10) || 0;
-  const jsonBody = lines.slice(0, -1).join('\n');
-
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(jsonBody);
-  } catch {
-    parsed = { raw: jsonBody };
-  }
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: ac.signal,
+    });
 
-  return { status: statusCode, body: parsed };
+    const rawBody = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = rawBody ? JSON.parse(rawBody) : {};
+    } catch {
+      parsed = { raw: rawBody };
+    }
+
+    return { status: response.status, body: parsed };
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') {
+      throw new Error(`LLM API timeout after ${timeout}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // ─── LlmAdapter ──────────────────────────────────────────────
@@ -220,6 +241,14 @@ export class LlmAdapter extends BaseAdapter {
 
   /** @internal — test-only override for shellExec */
   _exec: typeof shellExec = shellExec;
+
+  /** @internal — test-only override for HTTP transport */
+  _fetch: FetchLike =
+    typeof globalThis.fetch === 'function'
+      ? (globalThis.fetch as unknown as FetchLike)
+      : async () => {
+          throw new Error('global fetch is unavailable in this runtime');
+        };
 
   constructor(config: LlmConfig = { provider: 'generic' }) {
     super();
@@ -338,7 +367,7 @@ export class LlmAdapter extends BaseAdapter {
 
     let lastErr: Error | null = null;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      const resp = await httpPost(provider.url, provider.headers, body, this._timeout, this._exec);
+      const resp = await httpPost(provider.url, provider.headers, body, this._timeout, this._fetch);
 
       if (resp.status >= 200 && resp.status < 300) {
         return provider.parseResponse(resp.body);

--- a/src/webapp/routes/misc.ts
+++ b/src/webapp/routes/misc.ts
@@ -38,6 +38,32 @@ const HELP_TOC = [
 
 const MAX_EXPORT_SIZE = 10 * 1024 * 1024;
 
+type IntegrationReadinessStatus = 'ready' | 'partial' | 'not_ready';
+
+type IntegrationCheck = {
+  id: string;
+  passed: boolean;
+  detail: string;
+};
+
+function toReadinessStatus(checks: IntegrationCheck[]): IntegrationReadinessStatus {
+  const passed = checks.filter((check) => check.passed).length;
+  if (passed === checks.length) return 'ready';
+  if (passed === 0) return 'not_ready';
+  return 'partial';
+}
+
+function buildReadinessSummary(
+  status: IntegrationReadinessStatus,
+  checks: IntegrationCheck[]
+): string {
+  const passed = checks.filter((check) => check.passed).length;
+  const base = `${passed}/${checks.length} checks passed`;
+  if (status === 'ready') return `${base} — integration is operationally ready.`;
+  if (status === 'partial') return `${base} — integration is partially configured.`;
+  return `${base} — integration is not ready.`;
+}
+
 export async function registerRoutes(app: FastifyInstance, ctx: ServerContext): Promise<void> {
   const {
     _cache,
@@ -199,6 +225,88 @@ export async function registerRoutes(app: FastifyInstance, ctx: ServerContext): 
     reply.send({ entries: result.entries, total: result.total, limit });
   }
 
+  async function apiGetIntegrationReadiness(_request: FastifyRequest, reply: FastifyReply) {
+    const store = getStore();
+
+    const canvaChecks: IntegrationCheck[] = [
+      {
+        id: 'brand-agent-skill',
+        passed: store.exists(
+          path.join(PROJECT_ROOT, 'templates', 'sdlc', 'agents', '30-brand-assets-agent.md')
+        ),
+        detail: 'Brand & Assets (Canva) skill template is present',
+      },
+      {
+        id: 'canva-credentials',
+        passed: Boolean(process.env.CANVA_API_KEY || process.env.CANVA_ACCESS_TOKEN),
+        detail: 'CANVA_API_KEY or CANVA_ACCESS_TOKEN is configured',
+      },
+    ];
+
+    const storybookChecks: IntegrationCheck[] = [
+      {
+        id: 'storybook-config',
+        passed: store.exists(
+          path.join(PROJECT_ROOT, 'src', 'webapp', 'ui', '.storybook', 'main.ts')
+        ),
+        detail: 'Storybook config exists under src/webapp/ui/.storybook/main.ts',
+      },
+      {
+        id: 'storybook-package',
+        passed: store.exists(path.join(PROJECT_ROOT, 'src', 'webapp', 'ui', 'package.json')),
+        detail: 'UI package.json exists for Storybook scripts/dependencies',
+      },
+    ];
+
+    const matomoChecks: IntegrationCheck[] = [
+      {
+        id: 'matomo-compose',
+        passed: store.exists(path.join(PROJECT_ROOT, 'infra', 'docker-compose.analytics.yml')),
+        detail: 'Matomo docker-compose manifest exists',
+      },
+      {
+        id: 'matomo-env',
+        passed: Boolean(process.env.MATOMO_DB_PASSWORD || process.env.MATOMO_PORT),
+        detail: 'MATOMO_DB_PASSWORD or MATOMO_PORT environment variable is configured',
+      },
+    ];
+
+    const weblateChecks: IntegrationCheck[] = [
+      {
+        id: 'weblate-compose',
+        passed: store.exists(path.join(PROJECT_ROOT, 'infra', 'docker-compose.weblate.yml')),
+        detail: 'Weblate docker-compose manifest exists',
+      },
+      {
+        id: 'weblate-env',
+        passed: Boolean(process.env.WEBLATE_TOKEN || process.env.WEBLATE_ADMIN_PASSWORD),
+        detail: 'WEBLATE_TOKEN or WEBLATE_ADMIN_PASSWORD is configured',
+      },
+    ];
+
+    const integrations = [
+      { id: 'canva', label: 'Canva', checks: canvaChecks },
+      { id: 'storybook', label: 'Storybook', checks: storybookChecks },
+      { id: 'matomo', label: 'Matomo', checks: matomoChecks },
+      { id: 'weblate', label: 'Weblate', checks: weblateChecks },
+    ].map((integration) => {
+      const status = toReadinessStatus(integration.checks);
+      return {
+        id: integration.id,
+        label: integration.label,
+        status,
+        checks: integration.checks,
+        summary: buildReadinessSummary(status, integration.checks),
+      };
+    });
+
+    reply.send({
+      ok: true,
+      generated_at: models.isoNow(),
+      integrations,
+    });
+  }
+
   /* ── Register routes ────────────────────────────────────────── */
 
   app.get('/api/session', apiGetSession);
@@ -206,6 +314,11 @@ export async function registerRoutes(app: FastifyInstance, ctx: ServerContext): 
   app.get('/api/export', apiGetExport);
   app.get('/api/help', { schema: RS.helpGet }, apiGetHelp);
   app.get('/api/audit', { schema: RS.auditGet }, apiGetAudit);
+  app.get(
+    '/api/v1/integrations/readiness',
+    { schema: { tags: ['system'] } },
+    apiGetIntegrationReadiness
+  );
 
   registerHealthRoutes({
     app,

--- a/src/webapp/services/session-service.ts
+++ b/src/webapp/services/session-service.ts
@@ -10,10 +10,74 @@
 import path from 'path';
 import fsp from 'node:fs/promises';
 import { resolveSessionFile } from '../session-state-resolver';
-import type { ServiceContext, SessionState, ProgressInfo } from './types';
+import type { ServiceContext, SessionState, ProgressInfo, RuntimeAlert } from './types';
 import { buildEmptyPhases, buildPhaseProgress, buildProgressMcp } from './session/phase-progress';
 import { getHelpTopic, getHelpTopics } from './session/help';
 import { readSprintPlan, readSyncReports } from './session/drift';
+
+const DEFAULT_PHASE_TIMEOUT_MS = Number(process.env.PHASE_TIMEOUT_MS ?? 45 * 60 * 1000);
+const DEFAULT_STALL_ALERT_MS = Number(process.env.PHASE_STALL_ALERT_MS ?? 15 * 60 * 1000);
+
+function parseIsoMs(value: string | undefined | null): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function formatDurationMinutes(ms: number): string {
+  const minutes = Math.max(1, Math.round(ms / 60000));
+  return `${minutes} minute(s)`;
+}
+
+function shouldEvaluateRuntimeAlerts(session: SessionState): boolean {
+  const status = String(session.status || '').toUpperCase();
+  return !['COMPLETED', 'COMPLETE', 'FAILED', 'ERROR', 'PAUSED', 'IDLE', 'STOPPED'].includes(
+    status
+  );
+}
+
+function buildRuntimeAlerts(session: SessionState): RuntimeAlert[] {
+  if (!shouldEvaluateRuntimeAlerts(session)) return [];
+
+  const now = Date.now();
+  const phaseStartedAt =
+    parseIsoMs(session.phase_started_at) ??
+    parseIsoMs(session.initiated_at) ??
+    parseIsoMs(session.last_updated);
+  const lastUpdatedAt = parseIsoMs(session.last_updated) ?? phaseStartedAt;
+
+  if (!phaseStartedAt || !lastUpdatedAt) return [];
+
+  const alerts: RuntimeAlert[] = [];
+  const phaseElapsedMs = now - phaseStartedAt;
+  const idleForMs = now - lastUpdatedAt;
+
+  if (phaseElapsedMs > DEFAULT_PHASE_TIMEOUT_MS) {
+    alerts.push({
+      id: 'phase-timeout',
+      kind: 'timeout',
+      severity: 'critical',
+      title: 'Phase wall-clock timeout exceeded',
+      detail: `Current phase has been active for ${formatDurationMinutes(phaseElapsedMs)} (threshold ${formatDurationMinutes(DEFAULT_PHASE_TIMEOUT_MS)}).`,
+      next_action:
+        'Review blockers, decide whether to reroute, or pause and resume with an updated command.',
+    });
+  }
+
+  if (idleForMs > DEFAULT_STALL_ALERT_MS) {
+    alerts.push({
+      id: 'phase-stall',
+      kind: 'stall',
+      severity: 'warning',
+      title: 'Execution appears stalled',
+      detail: `No session update has been recorded for ${formatDurationMinutes(idleForMs)} (threshold ${formatDurationMinutes(DEFAULT_STALL_ALERT_MS)}).`,
+      next_action:
+        'Inspect active agent logs and queue state, then resume, retry, or escalate to human review.',
+    });
+  }
+
+  return alerts;
+}
 
 export class SessionService {
   private ctx: ServiceContext;
@@ -59,7 +123,12 @@ export class SessionService {
     key: string;
     label: string;
     status: string;
-    agents: Array<{ id: string; name: string; status: string }>;
+    agents: Array<{
+      id: string;
+      name: string;
+      status: string;
+      automation_level: 'autonomous' | 'supervised' | 'human_required';
+    }>;
     done: number;
     total: number;
   }> {
@@ -72,7 +141,12 @@ export class SessionService {
     key: string;
     label: string;
     status: string;
-    agents: Array<{ id: string; name: string; status: string }>;
+    agents: Array<{
+      id: string;
+      name: string;
+      status: string;
+      automation_level: 'autonomous' | 'supervised' | 'human_required';
+    }>;
     done: number;
     total: number;
   }> {
@@ -82,6 +156,7 @@ export class SessionService {
   /* ── Build session summary object ───────────────────────────── */
 
   buildSessionSummary(session: SessionState): Record<string, unknown> {
+    const runtimeAlerts = buildRuntimeAlerts(session);
     return {
       session_id: session.session_id,
       cycle_type: session.cycle_type,
@@ -96,6 +171,11 @@ export class SessionService {
       open_human_escalations: (session.open_human_escalations || []).filter(
         (e) => e.status === 'OPEN'
       ),
+      runtime_alerts: runtimeAlerts,
+      phase_watch: {
+        timeout_ms: DEFAULT_PHASE_TIMEOUT_MS,
+        stall_alert_ms: DEFAULT_STALL_ALERT_MS,
+      },
     };
   }
 

--- a/src/webapp/services/session/phase-progress.ts
+++ b/src/webapp/services/session/phase-progress.ts
@@ -7,16 +7,32 @@ import {
 } from '../../../../platform/engine/dispatcher';
 import { STATES } from '../../../../platform/engine/state-machine';
 
-type AgentDef = { id: string; name: string };
+type AgentAutomationLevel = 'autonomous' | 'supervised' | 'human_required';
+
+type AgentDef = { id: string; name: string; automation_level: AgentAutomationLevel };
 
 type PhaseProgressItem = {
   key: string;
   label: string;
   status: string;
-  agents: Array<{ id: string; name: string; status: string }>;
+  agents: Array<{
+    id: string;
+    name: string;
+    status: string;
+    automation_level: AgentAutomationLevel;
+  }>;
   done: number;
   total: number;
 };
+
+const SUPERVISED_AGENT_IDS = new Set(['00', '18', '19', '21', '22', '29', '38']);
+const HUMAN_REQUIRED_AGENT_IDS = new Set(['33', '36']);
+
+function resolveAutomationLevel(agentId: string): AgentAutomationLevel {
+  if (HUMAN_REQUIRED_AGENT_IDS.has(agentId)) return 'human_required';
+  if (SUPERVISED_AGENT_IDS.has(agentId)) return 'supervised';
+  return 'autonomous';
+}
 
 const PHASE_ORDER = [
   'ONBOARDING',
@@ -57,12 +73,17 @@ function compileProgressPhaseAgents(runtimePhaseAgents: Record<string, AgentDef[
     phaseAgents[progressPhase] = (runtimePhaseAgents[runtimeState] || []).map((agent) => ({
       id: agent.id,
       name: agent.name,
+      automation_level: resolveAutomationLevel(agent.id),
     }));
   }
 
   // Preserve critic gate visibility in phase progress while keeping phase
   // specialists sourced from canonical runtime schema.
-  const criticRollup: AgentDef = { id: 'critic_risk', name: 'Critic + Risk' };
+  const criticRollup: AgentDef = {
+    id: 'critic_risk',
+    name: 'Critic + Risk',
+    automation_level: 'supervised',
+  };
   for (const phaseKey of ['PHASE-1', 'PHASE-2', 'PHASE-3', 'PHASE-4']) {
     phaseAgents[phaseKey].push({ ...criticRollup });
   }
@@ -187,6 +208,7 @@ export function buildPhaseProgress(session: SessionState): PhaseProgressItem[] {
         currentAgents,
         phaseOutputs
       ),
+      automation_level: a.automation_level,
     }));
 
     const phaseStatus = resolvePhaseStatus(phaseKey, completedPhases, currentPhase, session);
@@ -212,6 +234,7 @@ export function buildEmptyPhases(): PhaseProgressItem[] {
       id: a.id,
       name: a.name,
       status: 'pending',
+      automation_level: a.automation_level,
     })),
     done: 0,
     total: (PHASE_AGENTS[key] || []).length,

--- a/src/webapp/services/types.ts
+++ b/src/webapp/services/types.ts
@@ -178,6 +178,7 @@ export interface SessionState {
   current_step?: string | null;
   initiated_at?: string;
   last_updated?: string;
+  phase_started_at?: string;
   phases?: unknown[];
   activeSprint?: unknown | null;
   completed_phases?: string[];
@@ -190,6 +191,15 @@ export interface SessionState {
   };
   blockers?: unknown[];
   open_human_escalations?: Array<{ status: string; [k: string]: unknown }>;
+}
+
+export interface RuntimeAlert {
+  id: string;
+  kind: 'timeout' | 'stall';
+  severity: 'warning' | 'critical';
+  title: string;
+  detail: string;
+  next_action: string;
 }
 
 export interface ProgressInfo {

--- a/src/webapp/ui/src/hooks/use-administration.ts
+++ b/src/webapp/ui/src/hooks/use-administration.ts
@@ -4,6 +4,7 @@ import { queryKeys } from '@/lib/query-keys';
 import type {
   AdminUsersResponse,
   AdministrationOverviewResponse,
+  ExternalIntegrationReadinessResponse,
   PolicySignalsResponse,
   TimestampedResponse,
   DashboardHealth,
@@ -22,10 +23,11 @@ export function useAdministrationOverview() {
   return useQuery({
     queryKey: queryKeys.administration.integrations,
     queryFn: async (): Promise<AdministrationOverviewResponse> => {
-      const [usersRes, signalsRes, healthRes] = await Promise.all([
+      const [usersRes, signalsRes, healthRes, readinessRes] = await Promise.all([
         apiGet<AdminUsersResponse>('/admin/users'),
         apiGet<PolicySignalsResponse>('/v1/policies/signals'),
         apiGet<TimestampedResponse<DashboardHealth>>('/dashboard/health'),
+        apiGet<ExternalIntegrationReadinessResponse>('/v1/integrations/readiness'),
       ]);
 
       const role_counts = {
@@ -67,6 +69,16 @@ export function useAdministrationOverview() {
               : 'offline') as 'healthy' | 'degraded' | 'offline',
           detail: String(healthRes.data.deployment.details ?? healthRes.data.deployment.label),
         },
+        ...readinessRes.integrations.map((integration) => ({
+          id: `external-${integration.id}`,
+          label: `${integration.label} readiness`,
+          status: (integration.status === 'ready'
+            ? 'healthy'
+            : integration.status === 'partial'
+              ? 'degraded'
+              : 'offline') as 'healthy' | 'degraded' | 'offline',
+          detail: integration.summary,
+        })),
       ];
 
       return {

--- a/src/webapp/ui/src/lib/api-types.ts
+++ b/src/webapp/ui/src/lib/api-types.ts
@@ -548,11 +548,13 @@ export interface DriftResponse {
  * ────────────────────────────────────────────── */
 
 export type AgentStatus = 'pending' | 'active' | 'done';
+export type AgentAutomationLevel = 'autonomous' | 'supervised' | 'human_required';
 
 export interface AgentEntry {
   id: string;
   name: string;
   status: AgentStatus;
+  automation_level?: AgentAutomationLevel;
 }
 
 export type PhaseKey = 'ONBOARDING' | 'PHASE-1' | 'PHASE-2' | 'PHASE-3' | 'PHASE-4' | 'PHASE-5';
@@ -578,6 +580,18 @@ export interface SessionInfo {
   last_updated: string;
   blockers: unknown[];
   open_human_escalations: unknown[];
+  runtime_alerts?: Array<{
+    id: string;
+    kind: 'timeout' | 'stall';
+    severity: 'warning' | 'critical';
+    title: string;
+    detail: string;
+    next_action: string;
+  }>;
+  phase_watch?: {
+    timeout_ms: number;
+    stall_alert_ms: number;
+  };
 }
 
 export interface ProgressResponse {
@@ -1368,6 +1382,23 @@ export interface AdministrationIntegrationStatus {
   label: string;
   status: 'healthy' | 'degraded' | 'offline';
   detail: string;
+}
+
+export interface ExternalIntegrationReadiness {
+  id: 'canva' | 'storybook' | 'matomo' | 'weblate';
+  label: string;
+  status: 'ready' | 'partial' | 'not_ready';
+  checks: Array<{
+    id: string;
+    passed: boolean;
+    detail: string;
+  }>;
+  summary: string;
+}
+
+export interface ExternalIntegrationReadinessResponse extends OkResponse {
+  generated_at: string;
+  integrations: ExternalIntegrationReadiness[];
 }
 
 export interface AdministrationOverviewResponse extends OkResponse {

--- a/src/webapp/ui/src/pages/pipeline/pipeline-page.tsx
+++ b/src/webapp/ui/src/pages/pipeline/pipeline-page.tsx
@@ -47,6 +47,14 @@ interface SwimlanePhase extends Omit<PhaseEntry, 'agents' | 'status'> {
   humanBlockers: number;
 }
 
+type GuidanceCard = {
+  id: string;
+  title: string;
+  blocker: string;
+  nextAction: string;
+  tone: 'warning' | 'critical' | 'info';
+};
+
 const laneTone: Record<SwimlaneStatus, 'default' | 'info' | 'warning' | 'success'> = {
   pending: 'default',
   active: 'info',
@@ -248,6 +256,48 @@ function getPipelineGuidance(
   };
 }
 
+function buildGuidanceCards(input: {
+  session: SessionInfo | null;
+  openEscalations: number;
+  humanBlockers: number;
+  fallbackActionLabel: string;
+}): GuidanceCard[] {
+  const cards: GuidanceCard[] = [];
+
+  if (input.openEscalations > 0 || input.humanBlockers > 0) {
+    cards.push({
+      id: 'human-blocker',
+      title: 'Human input required',
+      blocker: `${input.openEscalations} escalation(s) and ${input.humanBlockers} blocker(s) are currently open.`,
+      nextAction: 'Open the active session, resolve the pending question, then continue execution.',
+      tone: 'critical',
+    });
+  }
+
+  const runtimeAlerts = input.session?.runtime_alerts ?? [];
+  for (const alert of runtimeAlerts) {
+    cards.push({
+      id: `runtime-${alert.id}`,
+      title: alert.title,
+      blocker: alert.detail,
+      nextAction: alert.next_action,
+      tone: alert.severity === 'critical' ? 'critical' : 'warning',
+    });
+  }
+
+  if (cards.length === 0) {
+    cards.push({
+      id: 'default-guidance',
+      title: 'Pipeline is healthy',
+      blocker: 'No explicit blockers are active for the current run.',
+      nextAction: input.fallbackActionLabel,
+      tone: 'info',
+    });
+  }
+
+  return cards;
+}
+
 /* ── Main page ── */
 
 export default function PipelinePage() {
@@ -292,6 +342,12 @@ export default function PipelinePage() {
     openEscalations,
     humanBlockers
   );
+  const guidanceCards = buildGuidanceCards({
+    session: progress?.session ?? null,
+    openEscalations,
+    humanBlockers,
+    fallbackActionLabel: `${nextStep.actionLabel} to keep the pipeline moving.`,
+  });
   const activeAgentIds = getCurrentAgentIds(progress?.session ?? null);
   const activeAgentsLabel = formatCurrentAgentsLabel(activeAgentIds);
   const contextItems: ContextStripItem[] = [
@@ -359,6 +415,29 @@ export default function PipelinePage() {
       <PageHelpStrip routeSlug="pipeline" />
 
       <ContextStrip items={contextItems} />
+
+      <section aria-label="Blockers and next actions" className="grid gap-4 md:grid-cols-2">
+        {guidanceCards.map((card) => (
+          <Card key={card.id} elevation="flat" className="space-y-3 p-4">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-sm font-semibold">{card.title}</p>
+              <Badge
+                variant={
+                  card.tone === 'critical' ? 'error' : card.tone === 'warning' ? 'warning' : 'info'
+                }
+              >
+                {card.tone === 'critical'
+                  ? 'Blocking'
+                  : card.tone === 'warning'
+                    ? 'Attention'
+                    : 'Guidance'}
+              </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">{card.blocker}</p>
+            <p className="text-sm">{card.nextAction}</p>
+          </Card>
+        ))}
+      </section>
 
       <MissionControlHero
         heroId="pipeline"

--- a/tests/unit/p2-adapters-coverage.test.js
+++ b/tests/unit/p2-adapters-coverage.test.js
@@ -14,6 +14,40 @@ function injectMocks(adapter) {
   const mockExec = vi.fn();
   const mockAvail = vi.fn();
   adapter._exec = mockExec;
+  if ('_fetch' in adapter) {
+    adapter._fetch = async (url, init = {}) => {
+      const args = ['-X', init.method || 'POST'];
+      const headers = init.headers || {};
+      for (const [k, v] of Object.entries(headers)) {
+        args.push('-H', `${k}: ${v}`);
+      }
+      if (typeof init.body === 'string') {
+        args.push('-d', init.body);
+      }
+      args.push(url);
+
+      const mocked = await mockExec('fetch', args, { signal: init.signal });
+
+      if (mocked && typeof mocked.status === 'number' && typeof mocked.text === 'function') {
+        return mocked;
+      }
+
+      const stdout = typeof mocked?.stdout === 'string' ? mocked.stdout : '';
+      const lines = stdout.trimEnd().split('\n');
+      const statusFromTail = Number.parseInt(lines[lines.length - 1], 10);
+      const status = Number.isFinite(statusFromTail)
+        ? statusFromTail
+        : typeof mocked?.status === 'number'
+          ? mocked.status
+          : 500;
+      const body = Number.isFinite(statusFromTail) ? lines.slice(0, -1).join('\n') : stdout;
+
+      return {
+        status,
+        text: async () => body,
+      };
+    };
+  }
   if ('_isAvail' in adapter) adapter._isAvail = mockAvail;
   return { mockExec, mockAvail };
 }


### PR DESCRIPTION
## Summary\n- add CLI dry-run mode for config/runtime validation (#1100)\n- replace LLM curl subprocess transport with fetch-based HTTP (#1097)\n- add phase wall-clock timeout and stall alerts in progress/session data (#1091)\n- add blocker and next-action guidance cards in Pipeline UI (#1106)\n- add explicit Canva/Storybook/Matomo/Weblate readiness endpoint and admin integration view wiring (#1103)\n- add agent automation-level metadata in progress APIs (#1093)\n\n## Validation\n- npm run build\n- npm run lint\n- npm run test:coverage\n