### PR TITLE
feat: session re-auth event flow + synthesis gate validation

### DIFF
--- a/platform/engine/sprint-gate.ts
+++ b/platform/engine/sprint-gate.ts
@@ -77,6 +77,14 @@ const LESSONS_LEARNED_PATH = 'BusinessDocs/retrospectives/lessons-learned.md';
 const VELOCITY_LOG_PATH = 'BusinessDocs/retrospectives/velocity-log.json';
 const BLOCKER_MATRIX_PATH = 'BusinessDocs/synthesis/cross-team-blocker-matrix.md';
 const REEVALUATE_TRIGGER_PATH = 'BusinessDocs/session/reevaluate-trigger.json';
+const SYNTHESIS_REQUIRED_PATHS = [
+  'BusinessDocs/synthesis/final-report-master.md',
+  'BusinessDocs/synthesis/final-report-business.md',
+  'BusinessDocs/synthesis/final-report-tech.md',
+  'BusinessDocs/synthesis/final-report-ux.md',
+  'BusinessDocs/synthesis/final-report-marketing.md',
+  'BusinessDocs/synthesis/cross-team-blocker-matrix.md',
+];
 
 /** Trailing sprint count for velocity average */
 const VELOCITY_WINDOW = 3;
@@ -287,6 +295,65 @@ function loadDecisionsAndTriggers(
     blockingQuestions,
     reevaluate,
     activeCategories,
+  };
+}
+
+function validateSynthesisArtifacts(
+  store: SprintGateStore,
+  options: {
+    synthesisPaths?: string[];
+    minContentChars?: number;
+  } = {}
+) {
+  const synthesisPaths =
+    Array.isArray(options.synthesisPaths) && options.synthesisPaths.length > 0
+      ? options.synthesisPaths
+      : SYNTHESIS_REQUIRED_PATHS;
+  const minContentChars =
+    typeof options.minContentChars === 'number' && options.minContentChars > 0
+      ? options.minContentChars
+      : 80;
+
+  const issues: Array<Record<string, unknown>> = [];
+  const checkedFiles: Array<{ path: string; exists: boolean; chars: number }> = [];
+
+  for (const filePath of synthesisPaths) {
+    if (!store.exists(filePath)) {
+      checkedFiles.push({ path: filePath, exists: false, chars: 0 });
+      issues.push({
+        severity: 'CRITICAL',
+        rule: 'MISSING_SYNTHESIS_ARTIFACT',
+        description: `Missing required synthesis artifact: ${filePath}`,
+        path: filePath,
+      });
+      continue;
+    }
+
+    let chars = 0;
+    try {
+      chars = store.readFile(filePath).trim().length;
+    } catch {
+      chars = 0;
+    }
+
+    checkedFiles.push({ path: filePath, exists: true, chars });
+    if (chars < minContentChars) {
+      issues.push({
+        severity: 'CRITICAL',
+        rule: 'INVALID_SYNTHESIS_ARTIFACT',
+        description: `Synthesis artifact appears incomplete: ${filePath}`,
+        path: filePath,
+        actualChars: chars,
+        minChars: minContentChars,
+      });
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    checkedFiles,
+    minContentChars,
   };
 }
 
@@ -780,6 +847,17 @@ function runSprintGate(store: SprintGateStore, options: Record<string, unknown>)
   // Step 0: Decisions & reevaluate triggers
   const step0 = loadDecisionsAndTriggers(store, sprintId, paths, templateConfig);
 
+  // Step 0.5: Synthesis artifact re-validation
+  const step0_5 = validateSynthesisArtifacts(store, {
+    synthesisPaths: Array.isArray((paths as Record<string, unknown>).synthesisPaths)
+      ? ((paths as Record<string, unknown>).synthesisPaths as string[])
+      : undefined,
+    minContentChars:
+      typeof (paths as Record<string, unknown>).synthesisMinContentChars === 'number'
+        ? ((paths as Record<string, unknown>).synthesisMinContentChars as number)
+        : undefined,
+  });
+
   // Step 1: Definition of Ready
   const step1 = checkDefinitionOfReady(stories);
 
@@ -835,6 +913,9 @@ function runSprintGate(store: SprintGateStore, options: Record<string, unknown>)
     });
   }
 
+  // Step 0.5 blockers: synthesis output must be valid before planning proceeds.
+  allBlockers.push(...step0_5.issues.filter((i) => i.severity === 'CRITICAL'));
+
   // Step 1 blockers
   allBlockers.push(...step1.issues.filter((i) => i.severity === 'CRITICAL'));
 
@@ -867,6 +948,12 @@ function runSprintGate(store: SprintGateStore, options: Record<string, unknown>)
       blockingQuestions: step0.blockingQuestions,
       reevaluate: step0.reevaluate,
       activeCategories: step0.activeCategories,
+    },
+    step0_5_synthesisValidation: {
+      valid: step0_5.valid,
+      issues: step0_5.issues,
+      checkedFiles: step0_5.checkedFiles,
+      minContentChars: step0_5.minContentChars,
     },
     step1_definitionOfReady: {
       ready: step1.ready,
@@ -918,6 +1005,7 @@ function runSprintGate(store: SprintGateStore, options: Record<string, unknown>)
     velocityRatio: step3.ratio,
     openBlockerCount: step4.openBlockers.length,
     advisoryCount: step4.advisories.length,
+    synthesisIssues: step0_5.issues.length,
     decisionsLoaded: step0.decisions.length,
     activeCategoryCount: step0.activeCategories.length,
     policyFailures: step5.report?.summary.failed ?? 0,
@@ -1030,12 +1118,14 @@ export {
   VELOCITY_LOG_PATH,
   BLOCKER_MATRIX_PATH,
   REEVALUATE_TRIGGER_PATH,
+  SYNTHESIS_REQUIRED_PATHS,
   VELOCITY_WINDOW,
   CAPACITY_THRESHOLD,
   METRICS_STORE_PATH,
   parseDecisions,
   loadReevaluateTrigger,
   loadDecisionsAndTriggers,
+  validateSynthesisArtifacts,
   checkDefinitionOfReady,
   parseLessonsLearned,
   loadLessonsLearned,

--- a/src/webapp/ui/src/components/layout/app-layout.tsx
+++ b/src/webapp/ui/src/components/layout/app-layout.tsx
@@ -3,6 +3,7 @@
  * Uses React Router's <Outlet> for nested page rendering.
  */
 import { Suspense } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { TopNavigation } from '@/components/ui/top-navigation';
 import { type NavSection } from '@/components/ui/side-panel';
@@ -21,6 +22,8 @@ import { AppShell } from '@/components/layout/app-shell';
 import { SidebarNav } from '@/components/layout/sidebar-nav';
 import { BreadcrumbNav } from '@/components/layout/breadcrumb-nav';
 import { ChatPanel } from '@/components/chat/chat-panel';
+import { showToast } from '@/components/ui/toast-system';
+import { AUTH_EXPIRED_EVENT } from '@/lib/api-client';
 import {
   LayoutDashboard,
   Terminal,
@@ -143,6 +146,21 @@ export function AppLayout() {
 
   // Global keyboard shortcuts
   useKeyboardShortcuts();
+
+  useEffect(() => {
+    const onAuthExpired = () => {
+      const next = `${location.pathname}${location.search}${location.hash}`;
+      showToast.warning('Your session expired. Please sign in again to continue.');
+      navigate(`/login?reason=session-expired&next=${encodeURIComponent(next)}`, {
+        replace: true,
+      });
+    };
+
+    window.addEventListener(AUTH_EXPIRED_EVENT, onAuthExpired as EventListener);
+    return () => {
+      window.removeEventListener(AUTH_EXPIRED_EVENT, onAuthExpired as EventListener);
+    };
+  }, [location.hash, location.pathname, location.search, navigate]);
 
   return (
     <AppShell

--- a/src/webapp/ui/src/components/ui/access-guard.tsx
+++ b/src/webapp/ui/src/components/ui/access-guard.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { ShieldOff } from 'lucide-react';
 import { PageShell } from '@/components/ui/page-shell';
 import { useAuthorization, type RoleRequirement } from '@/hooks/use-auth';
@@ -11,6 +11,7 @@ interface AccessGuardProps {
 
 export function AccessGuard({ requiredRole, children }: AccessGuardProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user, loading, hasRequiredRole } = useAuthorization();
 
   if (!requiredRole) return <>{children}</>;
@@ -31,7 +32,15 @@ export function AccessGuard({ requiredRole, children }: AccessGuardProps) {
           icon: <ShieldOff className="size-8" />,
           title: 'Sign in required',
           description: 'You need an authenticated session to access this area.',
-          action: { label: 'Go to login', onClick: () => navigate('/login') },
+          action: {
+            label: 'Go to login',
+            onClick: () =>
+              navigate(
+                `/login?reason=auth-required&next=${encodeURIComponent(
+                  `${location.pathname}${location.search}${location.hash}`
+                )}`
+              ),
+          },
         }}
       >
         {null}

--- a/src/webapp/ui/src/lib/api-client.test.ts
+++ b/src/webapp/ui/src/lib/api-client.test.ts
@@ -2,7 +2,15 @@
  * Tests: API client utility
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { apiGet, apiPost, apiPut, apiPatch, apiDelete, ApiError } from '@/lib/api-client';
+import {
+  apiGet,
+  apiPost,
+  apiPut,
+  apiPatch,
+  apiDelete,
+  ApiError,
+  AUTH_EXPIRED_EVENT,
+} from '@/lib/api-client';
 
 describe('api-client', () => {
   const originalFetch = globalThis.fetch;
@@ -82,5 +90,16 @@ describe('api-client', () => {
     } catch (e) {
       expect((e as ApiError).message).toBe('Test Status');
     }
+  });
+
+  it('dispatches auth-expired event on 401 responses', async () => {
+    const listener = vi.fn();
+    window.addEventListener(AUTH_EXPIRED_EVENT, listener as EventListener);
+
+    mockFetch(401, { error: 'Unauthorized' });
+    await expect(apiGet('/auth/check')).rejects.toThrow(ApiError);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(AUTH_EXPIRED_EVENT, listener as EventListener);
   });
 });

--- a/src/webapp/ui/src/lib/api-client.ts
+++ b/src/webapp/ui/src/lib/api-client.ts
@@ -15,9 +15,32 @@ export class ApiError extends Error {
 }
 
 const BASE_URL = '/api';
+export const AUTH_EXPIRED_EVENT = 'agentic:auth-expired';
+const AUTH_EXPIRED_DEBOUNCE_MS = 15_000;
+
+let lastAuthExpiredEventAt = 0;
+
+function emitAuthExpiredEvent(status: number, endpoint: string): void {
+  if (typeof window === 'undefined') return;
+  const now = Date.now();
+  if (now - lastAuthExpiredEventAt < AUTH_EXPIRED_DEBOUNCE_MS) return;
+  lastAuthExpiredEventAt = now;
+  window.dispatchEvent(
+    new CustomEvent(AUTH_EXPIRED_EVENT, {
+      detail: {
+        status,
+        endpoint,
+        at: new Date(now).toISOString(),
+      },
+    })
+  );
+}
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
+    if (response.status === 401) {
+      emitAuthExpiredEvent(response.status, response.url || 'unknown');
+    }
     let body: unknown;
     try {
       body = await response.json();

--- a/src/webapp/ui/src/pages/login/login-page.tsx
+++ b/src/webapp/ui/src/pages/login/login-page.tsx
@@ -46,6 +46,15 @@ export default function LoginPage() {
   const [validationError, setValidationError] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
 
+  const search = new URLSearchParams(window.location.search);
+  const reason = search.get('reason');
+  const reasonMessage =
+    reason === 'session-expired'
+      ? 'Your session has expired. Sign in again to continue where you left off.'
+      : reason === 'auth-required'
+        ? 'Sign in is required to access that page.'
+        : null;
+
   const checkAuthAvailability = useCallback(async () => {
     try {
       const response = await fetch('/api/auth/me', { credentials: 'include' });
@@ -169,6 +178,15 @@ export default function LoginPage() {
             <Text className="text-muted-foreground text-sm">Sign in to access the platform.</Text>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
+            {reasonMessage && (
+              <AlertBanner variant="warning" icon={<AlertTriangle className="size-4" />}>
+                <div className="space-y-1">
+                  <Text className="font-medium">Re-authentication required</Text>
+                  <Text className="text-sm">{reasonMessage}</Text>
+                </div>
+              </AlertBanner>
+            )}
+
             {!authStatus.available && (
               <AlertBanner variant="error" icon={<AlertTriangle className="size-4" />}>
                 <div className="space-y-1">

--- a/tests/unit/sprint-gate.test.js
+++ b/tests/unit/sprint-gate.test.js
@@ -30,8 +30,10 @@ const {
   VELOCITY_LOG_PATH,
   BLOCKER_MATRIX_PATH,
   REEVALUATE_TRIGGER_PATH,
+  SYNTHESIS_REQUIRED_PATHS,
   VELOCITY_WINDOW,
   CAPACITY_THRESHOLD,
+  validateSynthesisArtifacts,
 } = require('../../platform/engine/sprint-gate');
 
 // ─── Test Helpers ────────────────────────────────────────────
@@ -173,6 +175,15 @@ function buildStory(overrides = {}) {
     dependencies: [],
     ...overrides,
   };
+}
+
+function buildSynthesisFiles(paths = SYNTHESIS_REQUIRED_PATHS) {
+  return Object.fromEntries(
+    paths.map((p) => [
+      p,
+      '# Synthesis Report\n\nThis artifact contains validated synthesis content and operator-ready planning guidance for sprint gating.',
+    ])
+  );
 }
 
 // ═════════════════════════════════════════════════════════════
@@ -766,12 +777,37 @@ describe('checkBlockers', () => {
   });
 });
 
+describe('validateSynthesisArtifacts', () => {
+  test('passes when all required synthesis artifacts exist with content', () => {
+    const files = buildSynthesisFiles();
+    const store = createMockStore(files);
+    const result = validateSynthesisArtifacts(store);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.checkedFiles).toHaveLength(SYNTHESIS_REQUIRED_PATHS.length);
+  });
+
+  test('fails when a required synthesis artifact is missing', () => {
+    const files = Object.fromEntries(
+      SYNTHESIS_REQUIRED_PATHS.slice(1).map((p) => [p, '# Report\n\ncontent'])
+    );
+    const store = createMockStore(files);
+    const result = validateSynthesisArtifacts(store);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.rule === 'MISSING_SYNTHESIS_ARTIFACT')).toBe(true);
+  });
+});
+
 // ═════════════════════════════════════════════════════════════
 // AC-7: SPRINT GATE RUNNER — VERDICT
 // ═════════════════════════════════════════════════════════════
 
 describe('runSprintGate', () => {
   function buildFullStore(overrides = {}) {
+    const synthesisFixtures = buildSynthesisFiles(
+      SYNTHESIS_REQUIRED_PATHS.filter((p) => p !== BLOCKER_MATRIX_PATH)
+    );
+
     return createMockStore({
       [DECISIONS_PATH]: overrides.decisions || buildDecisionsMd(),
       [LESSONS_LEARNED_PATH]:
@@ -797,6 +833,7 @@ describe('runSprintGate', () => {
             status: 'RESOLVED',
           },
         ]),
+      ...synthesisFixtures,
       ...(overrides.extra || {}),
     });
   }
@@ -965,13 +1002,14 @@ describe('runSprintGate', () => {
     expect(s).toHaveProperty('timestamp');
   });
 
-  test('steps object contains all 5 step results', () => {
+  test('steps object contains all sprint-gate step results', () => {
     const store = buildFullStore();
     const result = runSprintGate(store, {
       sprintId: 'SP-5',
       stories: [buildStory()],
     });
     expect(result.steps).toHaveProperty('step0_decisions');
+    expect(result.steps).toHaveProperty('step0_5_synthesisValidation');
     expect(result.steps).toHaveProperty('step1_definitionOfReady');
     expect(result.steps).toHaveProperty('step2_lessonsLearned');
     expect(result.steps).toHaveProperty('step3_velocityCapacity');
@@ -1001,30 +1039,53 @@ describe('runSprintGate', () => {
     expect(result.summary.exitCriteria.unmet.some((c) => c.id === 'B1-SPR-003')).toBe(true);
   });
 
+  test('returns NOT_READY when synthesis artifacts fail validation', () => {
+    const store = buildFullStore();
+    delete store._files['BusinessDocs/synthesis/final-report-master.md'];
+    const result = runSprintGate(store, {
+      sprintId: 'SP-5',
+      stories: [buildStory()],
+    });
+    expect(result.verdict).toBe('NOT_READY');
+    expect(result.blockers.some((b) => b.rule === 'MISSING_SYNTHESIS_ARTIFACT')).toBe(true);
+    expect(result.steps.step0_5_synthesisValidation.valid).toBe(false);
+  });
+
   test('handles gracefully when all data files are missing', () => {
     const store = createMockStore({});
     const result = runSprintGate(store, {
       sprintId: 'SP-5',
       stories: [buildStory()],
     });
-    // Should still produce a verdict (READY since no blockers detected from missing files)
-    expect(result.verdict).toBe('READY');
+    // Missing required synthesis artifacts must block sprint planning.
+    expect(result.verdict).toBe('NOT_READY');
+    expect(result.blockers.some((b) => b.rule === 'MISSING_SYNTHESIS_ARTIFACT')).toBe(true);
     expect(result.steps.step2_lessonsLearned.count).toBe(0);
   });
 
   test('accepts custom paths for all data files', () => {
+    const customSynthesisPaths = [
+      'custom/synthesis-master.md',
+      'custom/synthesis-business.md',
+      'custom/synthesis-tech.md',
+      'custom/synthesis-ux.md',
+      'custom/synthesis-marketing.md',
+      'custom/blockers.md',
+    ];
     const customPaths = {
       decisionsPath: 'custom/decisions.md',
       lessonsPath: 'custom/lessons.md',
       velocityPath: 'custom/velocity.json',
       blockerPath: 'custom/blockers.md',
       triggerPath: 'custom/trigger.json',
+      synthesisPaths: customSynthesisPaths,
     };
     const store = createMockStore({
       'custom/decisions.md': buildDecisionsMd(),
       'custom/lessons.md': buildLessonsLearnedMd(),
       'custom/velocity.json': buildVelocityLogJson([{ id: 'SP-1', planned: 5, completed: 5 }]),
       'custom/blockers.md': buildBlockerMatrixMd([]),
+      ...buildSynthesisFiles(customSynthesisPaths.filter((p) => p !== 'custom/blockers.md')),
     });
     const result = runSprintGate(store, {
       sprintId: 'SP-5',
@@ -1116,6 +1177,7 @@ describe('engine integration — sprintGate', () => {
       [LESSONS_LEARNED_PATH]: buildLessonsLearnedMd(),
       [VELOCITY_LOG_PATH]: buildVelocityLogJson([{ id: 'SP-1', planned: 10, completed: 10 }]),
       [BLOCKER_MATRIX_PATH]: buildBlockerMatrixMd([]),
+      ...buildSynthesisFiles(SYNTHESIS_REQUIRED_PATHS.filter((p) => p !== BLOCKER_MATRIX_PATH)),
     });
     const engine = createEngine({
       store,


### PR DESCRIPTION
## Summary

Implements two real gaps identified in the P1/next-15-issues batch analysis:

1. **Standardized session re-auth UX** — consistent flow when a user's session expires or they hit an auth-required route
2. **Synthesis artifact re-validation in sprint gate** — blocks sprint gate with CRITICAL issues when synthesis artifacts are missing or empty

---

## Changes

### `src/webapp/ui/src/lib/api-client.ts`
- Added `AUTH_EXPIRED_EVENT = 'agentic:auth-expired'` custom event constant
- Added debounced `emitAuthExpiredEvent()` (15s cooldown) dispatched on every 401 response

### `src/webapp/ui/src/components/layout/app-layout.tsx`
- Subscribes to `AUTH_EXPIRED_EVENT` via `useEffect`
- Shows a warning toast and redirects to `/login?reason=session-expired&next=<encoded-return-path>`

### `src/webapp/ui/src/components/ui/access-guard.tsx`
- Unauthenticated redirects now include `reason=auth-required` and encoded return path
- Enables login page to show context-aware re-auth messaging

### `src/webapp/ui/src/pages/login/login-page.tsx`
- Reads `reason` query param (`session-expired` / `auth-required`) via `window.location.search`
- Displays contextual `AlertBanner` with warning variant when applicable

### `platform/engine/sprint-gate.ts`
- Added `SYNTHESIS_REQUIRED_PATHS` constant (6 required synthesis artifact paths)
- Added `validateSynthesisArtifacts()` function — checks existence and minimum content length (≥80 chars)
- Wired as **step 0.5** in `runSprintGate()` — runs after decisions, before all other checks
- Exposes `steps.step0_5_synthesisValidation` and `summary.synthesisIssues` in gate output
- Exported `SYNTHESIS_REQUIRED_PATHS` and `validateSynthesisArtifacts`

### Tests
- `src/webapp/ui/src/lib/api-client.test.ts` — new test: dispatches auth-expired event on 401
- `tests/unit/sprint-gate.test.js` — added `validateSynthesisArtifacts` describe block, synthesis-blocking runSprintGate tests, updated fixtures

---

## Validation

| Gate | Result |
|------|--------|
| `npm run format` | ✅ clean |
| `npm run lint` | ✅ 0 warnings |
| `npm run test:coverage` | ✅ 4033/4033 tests passing (190 test files) |
| `npm run build` | ✅ clean, 2079 modules |