### PR TITLE
M0.1: Runtime profile hard gates + canonical approval decision schema

### DIFF
--- a/platform/engine/agent-runtime-adapter.ts
+++ b/platform/engine/agent-runtime-adapter.ts
@@ -1476,6 +1476,11 @@ export function resolveAdapter(config: {
   registry?: AdapterRegistry;
 }): AdapterResolutionResult {
   const registry = config.registry ?? DEFAULT_REGISTRY;
+  const profile = config.profile;
+  const isProductionProfile = Boolean(profile && profile.startsWith('production-'));
+
+  const isDisallowedProductionAdapter = (adapterName: string): boolean =>
+    adapterName === 'null' || adapterName === 'log-only';
 
   if (config.adapterName) {
     const adapter = registry.get(config.adapterName);
@@ -1487,11 +1492,30 @@ export function resolveAdapter(config: {
           `Available adapters: ${registry.listNames().join(', ')}.`,
       };
     }
+
+    if (isProductionProfile && isDisallowedProductionAdapter(config.adapterName)) {
+      return {
+        adapter: null,
+        error:
+          `Runtime profile '${profile}' forbids AGENT_RUNTIME_ADAPTER='${config.adapterName}'. ` +
+          `Configure a provider-backed adapter (for example: llm-openai, llm-copilot).`,
+      };
+    }
+
     return { adapter, error: null };
   }
 
+  if (isProductionProfile) {
+    return {
+      adapter: null,
+      error:
+        `Runtime profile '${profile}' requires AGENT_RUNTIME_ADAPTER to be explicitly configured. ` +
+        `Refusing default fail-open adapter selection.`,
+    };
+  }
+
   // Profile-based default: ci-test uses the no-op null adapter for determinism.
-  const defaultName = config.profile === 'ci-test' ? 'null' : 'log-only';
+  const defaultName = profile === 'ci-test' ? 'null' : 'log-only';
   const adapter = registry.get(defaultName) ?? null;
   return { adapter, error: null };
 }

--- a/src/webapp/routes/orchestrator.ts
+++ b/src/webapp/routes/orchestrator.ts
@@ -27,6 +27,7 @@ import { listTemplates, seedDecisions } from '../../../platform/engine/template-
 import { errorResponse } from '../utils/errors';
 import { structuredLog } from '../middleware';
 import { sessionTracker } from '../session-tracker';
+import { GovernanceService, ServiceNotAvailableError, toServiceContext } from '../services';
 import * as RS from '../route-schemas';
 import {
   HOST,
@@ -65,6 +66,10 @@ function getErrorMessage(err: unknown): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function shouldEnforceReviewGate(profile: string): boolean {
+  return profile.startsWith('production-');
 }
 
 function toSessionPhase(state: string): string | null {
@@ -263,6 +268,9 @@ function readHumanOverrideEvents(filePath: string): HumanOverrideEvent[] {
 export async function registerRoutes(app: FastifyInstance, ctx: ServerContext): Promise<void> {
   const { sseNotify } = ctx;
   const legacyCtx = ctx as unknown as Record<string, unknown>;
+  const governanceService = new GovernanceService(
+    toServiceContext(ctx as unknown as Record<string, unknown>)
+  );
   const humanOverridePath = path.join(
     getRepoRoot(legacyCtx),
     'BusinessDocs',
@@ -421,6 +429,55 @@ export async function registerRoutes(app: FastifyInstance, ctx: ServerContext): 
             .code(409)
             .send(errorResponse('ORCHESTRATOR_PAUSED', 'Orchestrator is paused. Resume first.'));
         }
+
+        const profile = validateProfile({
+          nodeEnv: process.env.NODE_ENV,
+          host: HOST,
+          storageProvider: STORAGE_PROVIDER,
+          queueProvider: QUEUE_PROVIDER,
+          sessionStore: SESSION_STORE,
+          redisUrl: REDIS_URL,
+          hasAuth: hasAuthConfigured({
+            githubClientId: process.env.GITHUB_CLIENT_ID,
+            apiKey: process.env.API_KEY,
+          }),
+          trustProxy: TRUST_PROXY,
+        }).profile;
+
+        let pendingApprovals = 0;
+        try {
+          pendingApprovals = governanceService.listApprovals().count;
+        } catch (err) {
+          if (!(err instanceof ServiceNotAvailableError)) {
+            structuredLog('warn', 'orchestrator_review_gate_check_failed', {
+              error: getErrorMessage(err),
+            });
+          }
+        }
+
+        if (shouldEnforceReviewGate(profile) && pendingApprovals > 0) {
+          const timestamp = new Date().toISOString();
+          structuredLog('warn', 'orchestrator_transition_blocked_review_gate', {
+            profile,
+            pendingApprovals,
+          });
+          sseNotify('orchestrator_transition_blocked', {
+            type: 'orchestrator_transition_blocked',
+            reason: 'pending_approvals',
+            profile,
+            pending_approvals: pendingApprovals,
+            timestamp,
+          });
+          return reply.code(409).send({
+            ...errorResponse(
+              'REVIEW_GATE_BLOCKED',
+              `Transition blocked: ${pendingApprovals} pending approval(s) require human decision.`
+            ),
+            profile,
+            pending_approvals: pendingApprovals,
+          });
+        }
+
         const engine = getEngine();
         const prevStatus = engine.status();
         const prevState = prevStatus.state;

--- a/src/webapp/services/agent-execution-service.ts
+++ b/src/webapp/services/agent-execution-service.ts
@@ -152,6 +152,24 @@ function resolvePredecessorContinuityMode():
       states?: string[];
       agents?: string[];
     } {
+  const runtimeProfile = validateProfile({
+    nodeEnv: process.env.NODE_ENV,
+    host: HOST,
+    storageProvider: STORAGE_PROVIDER,
+    queueProvider: QUEUE_PROVIDER,
+    sessionStore: SESSION_STORE,
+    redisUrl: REDIS_URL,
+    hasAuth: hasAuthConfigured({
+      githubClientId: process.env.GITHUB_CLIENT_ID,
+      apiKey: process.env.API_KEY,
+    }),
+    trustProxy: TRUST_PROXY,
+  }).profile;
+
+  return resolvePredecessorContractContinuityMode(runtimeProfile).mode;
+}
+
+function resolveRuntimeProfile() {
   const validation = validateProfile({
     nodeEnv: process.env.NODE_ENV,
     host: HOST,
@@ -166,7 +184,7 @@ function resolvePredecessorContinuityMode():
     trustProxy: TRUST_PROXY,
   });
 
-  return resolvePredecessorContractContinuityMode(validation.profile).mode;
+  return validation.profile;
 }
 
 export class AgentExecutionService {
@@ -215,7 +233,15 @@ export class AgentExecutionService {
     );
 
     // I-A1-003: resolve adapter from registry; Dispatcher uses it instead of bare throw.
-    const { adapter } = resolveAdapter({ adapterName: AGENT_RUNTIME_ADAPTER });
+    const runtimeProfile = resolveRuntimeProfile();
+    const { adapter, error: adapterResolutionError } = resolveAdapter({
+      adapterName: AGENT_RUNTIME_ADAPTER,
+      profile: runtimeProfile,
+    });
+    if (adapterResolutionError) {
+      throw new Error(adapterResolutionError);
+    }
+
     const dispatcher = new Dispatcher({
       store: getStore(),
       adapter: adapter ?? undefined,

--- a/src/webapp/services/governance-service.ts
+++ b/src/webapp/services/governance-service.ts
@@ -11,7 +11,12 @@ import path from 'path';
 import { GovernanceEngine as PersistedGovernanceEngine } from '../../../platform/sdlc/governance';
 import type { ApprovalRequest } from '../../../platform/sdlc/governance';
 import { ServiceValidationError } from './decisions-service';
-import type { ServiceContext, ApprovalItem, ApprovalDecisionResult } from './types';
+import type {
+  ServiceContext,
+  ApprovalItem,
+  ApprovalDecisionResult,
+  CanonicalApprovalDecision,
+} from './types';
 
 /** Minimal governance engine shape. */
 interface GovernanceEngine {
@@ -58,6 +63,28 @@ export class GovernanceService {
   private static readonly TOOL_EXEC_ESCALATION_GATE_ID = 'G-REL-03';
   private static readonly TOOL_EXEC_STAGE = 'RELEASE' as ApprovalRequest['stage'];
 
+  private toCanonicalDecision(
+    result: ApprovalRequest,
+    decidedBy: string
+  ): CanonicalApprovalDecision {
+    const decidedAt = result.decided_at || new Date().toISOString();
+    const decision: CanonicalApprovalDecision['decision'] =
+      result.status === 'APPROVED' ? 'APPROVED' : 'REJECTED';
+
+    return {
+      schema: 'approval-policy-decision',
+      version: '1.0',
+      decision,
+      approval_id: result.id,
+      entity_id: result.entity_id,
+      gate_id: result.gate_id,
+      stage: result.stage,
+      decided_by: result.decided_by || decidedBy,
+      decided_at: decidedAt,
+      reason: result.reason,
+    };
+  }
+
   /* ── List pending approvals ─────────────────────────────────── */
 
   listApprovals(): { approvals: ApprovalItem[]; count: number } {
@@ -93,15 +120,18 @@ export class GovernanceService {
 
     const result = engine.decide(approvalId, user, true, reason);
     engine.saveTo?.(this.ctx.store, this.governanceStatePath);
+    const decision = this.toCanonicalDecision(result, user);
+
     return {
       ok: true,
       approval: {
         id: result.id,
         status: result.status,
-        decided_by: result.decided_by || user,
-        decided_at: result.decided_at || new Date().toISOString(),
+        decided_by: decision.decided_by,
+        decided_at: decision.decided_at,
         reason: result.reason,
       },
+      decision,
     };
   }
 
@@ -115,15 +145,18 @@ export class GovernanceService {
 
     const result = engine.decide(approvalId, user, false, reason);
     engine.saveTo?.(this.ctx.store, this.governanceStatePath);
+    const decision = this.toCanonicalDecision(result, user);
+
     return {
       ok: true,
       approval: {
         id: result.id,
         status: result.status,
-        decided_by: result.decided_by || user,
-        decided_at: result.decided_at || new Date().toISOString(),
+        decided_by: decision.decided_by,
+        decided_at: decision.decided_at,
         reason: result.reason,
       },
+      decision,
     };
   }
 

--- a/src/webapp/services/types.ts
+++ b/src/webapp/services/types.ts
@@ -151,6 +151,19 @@ export interface ApprovalItem {
   status: string;
 }
 
+export interface CanonicalApprovalDecision {
+  schema: 'approval-policy-decision';
+  version: '1.0';
+  decision: 'APPROVED' | 'REJECTED';
+  approval_id: string;
+  entity_id: string;
+  gate_id: string;
+  stage: string;
+  decided_by: string;
+  decided_at: string;
+  reason: string;
+}
+
 export interface ApprovalDecisionResult {
   ok: boolean;
   approval: {
@@ -160,6 +173,7 @@ export interface ApprovalDecisionResult {
     decided_at: string;
     reason: string;
   };
+  decision: CanonicalApprovalDecision;
 }
 
 /* ── Session / progress types ─────────────────────────────────── */

--- a/src/webapp/utils/errors.ts
+++ b/src/webapp/utils/errors.ts
@@ -95,6 +95,10 @@ export const ERROR_CATALOG: Record<string, ErrorEntry> = {
     message: 'The orchestrator is paused by a human override.',
     recovery: 'Resume the orchestrator before advancing.',
   },
+  REVIEW_GATE_BLOCKED: {
+    message: 'Transition is blocked until required human approvals are resolved.',
+    recovery: 'Approve or reject all pending review items, then retry advance.',
+  },
   ALREADY_PAUSED: {
     message: 'The orchestrator is already paused.',
     recovery: 'Resume the orchestrator or continue with override operations.',

--- a/tests/unit/agent-runtime-adapter.test.js
+++ b/tests/unit/agent-runtime-adapter.test.js
@@ -268,6 +268,33 @@ describe('resolveAdapter', () => {
     expect(error).toBeNull();
     expect(adapter).toBeNull();
   });
+
+  it('fails closed for production profile without explicit adapter', () => {
+    const { adapter, error } = resolveAdapter({ profile: 'production-single-node' });
+
+    expect(adapter).toBeNull();
+    expect(error).toContain('requires AGENT_RUNTIME_ADAPTER');
+  });
+
+  it('rejects null adapter in production profile', () => {
+    const { adapter, error } = resolveAdapter({
+      adapterName: 'null',
+      profile: 'production-distributed',
+    });
+
+    expect(adapter).toBeNull();
+    expect(error).toContain("forbids AGENT_RUNTIME_ADAPTER='null'");
+  });
+
+  it('allows provider-backed adapters in production profile', () => {
+    const { adapter, error } = resolveAdapter({
+      adapterName: 'llm-mock',
+      profile: 'production-single-node',
+    });
+
+    expect(error).toBeNull();
+    expect(adapter).toBeInstanceOf(MockLlmRuntimeAdapter);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────

--- a/tests/unit/approvals-routes.test.js
+++ b/tests/unit/approvals-routes.test.js
@@ -198,6 +198,10 @@ describe('approveRequest', () => {
     expect(data.ok).toBe(true);
     expect(data.approval.status).toBe('APPROVED');
     expect(data.approval.decided_by).toBe('reviewer');
+    expect(data.decision.schema).toBe('approval-policy-decision');
+    expect(data.decision.version).toBe('1.0');
+    expect(data.decision.decision).toBe('APPROVED');
+    expect(data.decision.approval_id).toBe('APR-001');
     expect(ctx._notified).toHaveLength(1);
     expect(ctx._notified[0].action).toBe('approved');
   });
@@ -306,6 +310,10 @@ describe('rejectRequest', () => {
     expect(data.ok).toBe(true);
     expect(data.approval.status).toBe('REJECTED');
     expect(data.approval.decided_by).toBe('architect');
+    expect(data.decision.schema).toBe('approval-policy-decision');
+    expect(data.decision.version).toBe('1.0');
+    expect(data.decision.decision).toBe('REJECTED');
+    expect(data.decision.approval_id).toBe('APR-001');
     expect(ctx._notified).toHaveLength(1);
     expect(ctx._notified[0].action).toBe('rejected');
   });

--- a/tests/unit/routes-orchestrator.test.js
+++ b/tests/unit/routes-orchestrator.test.js
@@ -8,6 +8,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { registerRoutes } from '../../src/webapp/routes/orchestrator.js';
 import { sessionTracker } from '../../src/webapp/session-tracker.js';
+import { GovernanceService, toServiceContext } from '../../src/webapp/services/index.js';
 import { createTestableRoutes } from '../helpers/fastify-test-adapter.js';
 
 const createOrchestratorRoutes = (ctx) => createTestableRoutes(registerRoutes, ctx);
@@ -28,6 +29,14 @@ const HUMAN_OVERRIDE_FILE = path.resolve(
   'BusinessDocs',
   'session',
   'human-override-events.json'
+);
+const GOVERNANCE_STATE_FILE = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'BusinessDocs',
+  'session',
+  'governance-state.json'
 );
 const IDLE_STATE = JSON.stringify({ status: 'IDLE', mode: 'CREATE', state_history: [] });
 
@@ -76,11 +85,16 @@ describe('orchestrator routes (integration)', () => {
   let sseNotify;
   let originalSession;
   let originalHumanOverride;
+  let originalGovernanceState;
+  let routeCtx;
 
   beforeAll(() => {
     originalSession = fs.existsSync(SESSION_FILE) ? fs.readFileSync(SESSION_FILE, 'utf8') : null;
     originalHumanOverride = fs.existsSync(HUMAN_OVERRIDE_FILE)
       ? fs.readFileSync(HUMAN_OVERRIDE_FILE, 'utf8')
+      : null;
+    originalGovernanceState = fs.existsSync(GOVERNANCE_STATE_FILE)
+      ? fs.readFileSync(GOVERNANCE_STATE_FILE, 'utf8')
       : null;
   });
 
@@ -93,6 +107,11 @@ describe('orchestrator routes (integration)', () => {
     } else {
       fs.rmSync(HUMAN_OVERRIDE_FILE, { force: true });
     }
+    if (originalGovernanceState !== null) {
+      fs.writeFileSync(GOVERNANCE_STATE_FILE, originalGovernanceState);
+    } else {
+      fs.rmSync(GOVERNANCE_STATE_FILE, { force: true });
+    }
   });
 
   beforeEach(() => {
@@ -102,8 +121,14 @@ describe('orchestrator routes (integration)', () => {
     // Write clean IDLE state so each test starts fresh
     fs.writeFileSync(SESSION_FILE, IDLE_STATE);
     fs.rmSync(HUMAN_OVERRIDE_FILE, { force: true });
+    fs.rmSync(GOVERNANCE_STATE_FILE, { force: true });
     sseNotify = vi.fn();
-    routes = createTestableRoutes(registerRoutes, { sseNotify });
+    routeCtx = {
+      sseNotify,
+      PROJECT_ROOT: path.resolve(__dirname, '..', '..'),
+      SESSION_DIR: path.dirname(SESSION_FILE),
+    };
+    routes = createTestableRoutes(registerRoutes, routeCtx);
   });
 
   it('exports all 10 route handlers', () => {
@@ -264,6 +289,38 @@ describe('orchestrator routes (integration)', () => {
       expect(res.body.ok).toBe(true);
       expect(res.body.transition.from).toBe('IDLE');
       expect(res.body.transition.to).toBe('ONBOARDING');
+    });
+
+    it('blocks advance in production profile when approvals are pending', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      try {
+        const governanceService = new GovernanceService(toServiceContext(routeCtx));
+        governanceService.requestToolExecutionApproval({
+          entityId: 'orchestrator:advance:test',
+          requestedBy: 'qa-user',
+        });
+
+        const res = fakeRes();
+        await routes['POST /api/orchestrator/advance'](fakeReq({}), res);
+
+        expect(res.status).toBe(409);
+        expect(res.body.code).toBe('REVIEW_GATE_BLOCKED');
+        expect(res.body.pending_approvals).toBeGreaterThan(0);
+
+        const blockedEvent = sseNotify.mock.calls.find(
+          ([type, payload]) =>
+            type === 'orchestrator_transition_blocked' && payload.reason === 'pending_approvals'
+        );
+        expect(blockedEvent).toBeDefined();
+      } finally {
+        if (originalNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalNodeEnv;
+        }
+      }
     });
 
     it('advances with gateResult body field', async () => {


### PR DESCRIPTION
## Summary
Implements the M0.1 blocking slice for runtime and governance hard gates.

### Included
- Enforce production runtime adapter contract (fail-closed, no implicit null/log-only)
- Block orchestrator advance in production when pending approvals exist
- Add canonical approval decision schema to approval outcomes
- Extend tests for adapter enforcement, orchestrator hard gate, and approval decision contract

### Validation
- npm run format
- npm run lint
- npm run test:coverage

Closes #1181
Closes #1182
Closes #1183
Refs #1180