### PR TITLE
feat(m3): adaptive policy loop with safe auto-apply controls

### DIFF
--- a/platform/engine/lessons-to-policy.ts
+++ b/platform/engine/lessons-to-policy.ts
@@ -74,6 +74,37 @@ export interface PolicyChangeRecommendation {
   approvalAuthority: 'orchestrator' | 'human' | 'automated';
 }
 
+export type ProposalRiskClassification = 'low' | 'medium' | 'high';
+
+export interface BenchmarkThreshold {
+  maxP95LatencyMs: number;
+  maxErrorRatePct: number;
+  minSuccessRatePct: number;
+}
+
+export interface BenchmarkEvidence {
+  benchmarkRunId: string;
+  collectedAt: string;
+  metrics: {
+    p95LatencyMs: number;
+    errorRatePct: number;
+    successRatePct: number;
+  };
+  thresholds: BenchmarkThreshold;
+  passed: boolean;
+  failures: string[];
+}
+
+export interface PolicyAutoApplyResult {
+  proposalId: string;
+  attemptedAt: string;
+  autoApplied: boolean;
+  failClosed: boolean;
+  reasons: string[];
+  riskClassification: ProposalRiskClassification;
+  benchmarkEvidence: BenchmarkEvidence[];
+}
+
 /**
  * Policy change proposal document
  */
@@ -91,11 +122,40 @@ export interface PolicyChangeProposal {
     highRiskChanges: number;
     requiresApproval: number;
     confidenceScore: number;
+    riskClassification: ProposalRiskClassification;
   };
   recommendationStatus: 'pending-review' | 'approved' | 'rejected' | 'applied' | 'reverted';
   reviewNotes?: string;
   appliedAt?: string;
 }
+
+export interface RollbackJournalEntry {
+  entryId: string;
+  proposalId: string;
+  recordedAt: string;
+  appliedAt: string;
+  appliedBy: string;
+  reversibleCommand: string;
+  proposalSnapshot: {
+    recommendationStatus: PolicyChangeProposal['recommendationStatus'];
+    reviewNotes?: string;
+    appliedAt?: string;
+  };
+}
+
+const POLICY_CLASS_THRESHOLDS: Record<
+  PolicyChangeRecommendation['policyDomain'],
+  BenchmarkThreshold
+> = {
+  routing: { maxP95LatencyMs: 2600, maxErrorRatePct: 5, minSuccessRatePct: 95 },
+  'prompt-profile': { maxP95LatencyMs: 3000, maxErrorRatePct: 6, minSuccessRatePct: 94 },
+  'validation-strictness': { maxP95LatencyMs: 2800, maxErrorRatePct: 4, minSuccessRatePct: 96 },
+  'retrieval-profile': { maxP95LatencyMs: 3200, maxErrorRatePct: 5, minSuccessRatePct: 95 },
+  concurrency: { maxP95LatencyMs: 2400, maxErrorRatePct: 5, minSuccessRatePct: 95 },
+  'approval-threshold': { maxP95LatencyMs: 3000, maxErrorRatePct: 6, minSuccessRatePct: 94 },
+  'escalation-behavior': { maxP95LatencyMs: 3500, maxErrorRatePct: 6, minSuccessRatePct: 94 },
+  'cache-policy': { maxP95LatencyMs: 2500, maxErrorRatePct: 5, minSuccessRatePct: 95 },
+};
 
 export class LessonsToPolicyService {
   private ctx: ServiceContext;
@@ -122,6 +182,154 @@ export class LessonsToPolicyService {
   private appendText(filePath: string, content: string): void {
     const existing = this.readText(filePath) || '';
     this.writeText(filePath, `${existing}${content}`);
+  }
+
+  private emitAdaptationEvent(event: {
+    proposalId: string;
+    eventType:
+      | 'proposal-created'
+      | 'proposal-approved'
+      | 'auto-apply-attempted'
+      | 'auto-apply-failed-closed'
+      | 'proposal-applied'
+      | 'proposal-reverted';
+    details?: Record<string, unknown>;
+  }): void {
+    const row = {
+      timestamp: new Date().toISOString(),
+      ...event,
+    };
+    this.appendText('BusinessDocs/metrics/adaptation-events.jsonl', `${JSON.stringify(row)}\n`);
+  }
+
+  private classifyProposalRisk(
+    recommendations: PolicyChangeRecommendation[]
+  ): ProposalRiskClassification {
+    if (recommendations.some((recommendation) => recommendation.riskLevel === 'high')) {
+      return 'high';
+    }
+
+    if (recommendations.some((recommendation) => recommendation.riskLevel === 'medium')) {
+      return 'medium';
+    }
+
+    return 'low';
+  }
+
+  private parseBenchmarkMetrics(raw: unknown): {
+    p95LatencyMs: number;
+    errorRatePct: number;
+    successRatePct: number;
+  } | null {
+    if (!raw || typeof raw !== 'object') {
+      return null;
+    }
+
+    const row = raw as Record<string, unknown>;
+    const latency = row.latencyThresholds as Record<string, unknown> | undefined;
+    const p95Candidate = row.p95 ?? row.p95Ms ?? latency?.p95;
+    const errorCandidate = row.errorRatePct ?? row.errorRate ?? row.errorsPct;
+    const successCandidate = row.successRatePct ?? row.successRate;
+
+    const p95LatencyMs = typeof p95Candidate === 'number' ? p95Candidate : Number.NaN;
+    const errorRatePct = typeof errorCandidate === 'number' ? errorCandidate : Number.NaN;
+    const successRatePct =
+      typeof successCandidate === 'number' ? successCandidate : 100 - (errorRatePct || 0);
+
+    if (!Number.isFinite(p95LatencyMs) || !Number.isFinite(errorRatePct)) {
+      return null;
+    }
+
+    return {
+      p95LatencyMs,
+      errorRatePct,
+      successRatePct: Number.isFinite(successRatePct) ? successRatePct : 0,
+    };
+  }
+
+  private validateBenchmarkForThreshold(
+    benchmarkRunId: string,
+    threshold: BenchmarkThreshold
+  ): BenchmarkEvidence | null {
+    const benchmarkFilePath = `tests/load/${benchmarkRunId}.json`;
+    const benchmarkRaw = this.readText(benchmarkFilePath);
+    if (!benchmarkRaw) {
+      return null;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(benchmarkRaw);
+    } catch {
+      return null;
+    }
+
+    const metrics = this.parseBenchmarkMetrics(parsed);
+    if (!metrics) {
+      return null;
+    }
+
+    const failures: string[] = [];
+    if (metrics.p95LatencyMs > threshold.maxP95LatencyMs) {
+      failures.push(
+        `p95 latency ${metrics.p95LatencyMs}ms exceeds max ${threshold.maxP95LatencyMs}ms`
+      );
+    }
+    if (metrics.errorRatePct > threshold.maxErrorRatePct) {
+      failures.push(
+        `error rate ${metrics.errorRatePct}% exceeds max ${threshold.maxErrorRatePct}%`
+      );
+    }
+    if (metrics.successRatePct < threshold.minSuccessRatePct) {
+      failures.push(
+        `success rate ${metrics.successRatePct}% below min ${threshold.minSuccessRatePct}%`
+      );
+    }
+
+    return {
+      benchmarkRunId,
+      collectedAt: new Date().toISOString(),
+      metrics,
+      thresholds: threshold,
+      passed: failures.length === 0,
+      failures,
+    };
+  }
+
+  private collectBenchmarkEvidence(proposal: PolicyChangeProposal): BenchmarkEvidence[] {
+    const domains = Array.from(
+      new Set(proposal.recommendedChanges.map((change) => change.policyDomain))
+    );
+    const evidenceRows: BenchmarkEvidence[] = [];
+
+    for (const domain of domains) {
+      const threshold = POLICY_CLASS_THRESHOLDS[domain];
+      for (const benchmarkRunId of proposal.derivedFrom.benchmarkRunIds) {
+        const evidence = this.validateBenchmarkForThreshold(benchmarkRunId, threshold);
+        if (evidence) {
+          evidenceRows.push(evidence);
+        }
+      }
+    }
+
+    return evidenceRows;
+  }
+
+  private getProposalPath(proposalId: string): string {
+    return `BusinessDocs/intelligence-loop/policy-proposals/${proposalId}.json`;
+  }
+
+  private loadProposal(proposalId: string): PolicyChangeProposal {
+    const proposalPath = this.getProposalPath(proposalId);
+    const content = this.readText(proposalPath);
+    if (!content) {
+      throw new Error(`Proposal not found: ${proposalId}`);
+    }
+    return JSON.parse(content) as PolicyChangeProposal;
+  }
+
+  private persistProposal(proposal: PolicyChangeProposal): void {
+    this.writeText(this.getProposalPath(proposal.proposalId), JSON.stringify(proposal, null, 2));
   }
 
   /**
@@ -354,6 +562,7 @@ export class LessonsToPolicyService {
 
     const highRiskCount = recommendations.filter((r) => r.riskLevel === 'high').length;
     const approvalsRequired = recommendations.filter((r) => r.approvalRequired).length;
+    const riskClassification = this.classifyProposalRisk(recommendations);
     const confidenceScore =
       recommendations.length > 0
         ? recommendations.reduce(
@@ -376,24 +585,152 @@ export class LessonsToPolicyService {
         highRiskChanges: highRiskCount,
         requiresApproval: approvalsRequired,
         confidenceScore: Math.min(1, confidenceScore),
+        riskClassification,
       },
       recommendationStatus: 'pending-review',
     };
 
     // Persist the proposal
-    const proposalPath = `BusinessDocs/intelligence-loop/policy-proposals/${proposal.proposalId}.json`;
-    this.writeText(proposalPath, JSON.stringify(proposal, null, 2));
+    this.persistProposal(proposal);
+    this.emitAdaptationEvent({
+      proposalId: proposal.proposalId,
+      eventType: 'proposal-created',
+      details: {
+        riskClassification,
+        benchmarkRunIds: benchmarkRunIds.length,
+      },
+    });
 
     return proposal;
+  }
+
+  async approveProposal(
+    proposalId: string,
+    reviewer = 'orchestrator'
+  ): Promise<PolicyChangeProposal> {
+    const proposal = this.loadProposal(proposalId);
+    proposal.recommendationStatus = 'approved';
+    proposal.reviewNotes = `Approved by ${reviewer}`;
+    this.persistProposal(proposal);
+    this.emitAdaptationEvent({
+      proposalId,
+      eventType: 'proposal-approved',
+      details: { reviewer },
+    });
+    return proposal;
+  }
+
+  async autoApplyProposal(
+    proposalId: string,
+    actor = 'automated-pipeline'
+  ): Promise<PolicyAutoApplyResult> {
+    const proposal = this.loadProposal(proposalId);
+    const attemptedAt = new Date().toISOString();
+    const reasons: string[] = [];
+    const benchmarkEvidence = this.collectBenchmarkEvidence(proposal);
+    const riskClassification = proposal.summary.riskClassification;
+
+    if (riskClassification !== 'low') {
+      reasons.push(
+        `Proposal risk classification is '${riskClassification}', only 'low' is eligible.`
+      );
+    }
+
+    if (
+      proposal.recommendationStatus !== 'pending-review' &&
+      proposal.recommendationStatus !== 'approved'
+    ) {
+      reasons.push(
+        `Proposal status '${proposal.recommendationStatus}' is not eligible for auto-apply.`
+      );
+    }
+
+    const missingBenchmarkEvidence = benchmarkEvidence.length === 0;
+    if (missingBenchmarkEvidence) {
+      reasons.push('Required benchmark evidence is missing for this policy class.');
+    }
+
+    const failingBenchmarkEvidence = benchmarkEvidence.filter((evidence) => !evidence.passed);
+    if (failingBenchmarkEvidence.length > 0) {
+      reasons.push(
+        `Benchmark thresholds failed for ${failingBenchmarkEvidence.length} evidence record(s).`
+      );
+    }
+
+    const failClosed = missingBenchmarkEvidence || failingBenchmarkEvidence.length > 0;
+    this.emitAdaptationEvent({
+      proposalId,
+      eventType: 'auto-apply-attempted',
+      details: {
+        actor,
+        failClosed,
+        riskClassification,
+        benchmarkEvidenceCount: benchmarkEvidence.length,
+      },
+    });
+
+    if (reasons.length > 0) {
+      if (failClosed) {
+        this.emitAdaptationEvent({
+          proposalId,
+          eventType: 'auto-apply-failed-closed',
+          details: {
+            reasons,
+          },
+        });
+      }
+
+      return {
+        proposalId,
+        attemptedAt,
+        autoApplied: false,
+        failClosed,
+        reasons,
+        riskClassification,
+        benchmarkEvidence,
+      };
+    }
+
+    proposal.recommendationStatus = 'approved';
+    await this.applyProposal(proposal, actor);
+
+    return {
+      proposalId,
+      attemptedAt,
+      autoApplied: true,
+      failClosed,
+      reasons: ['All guard conditions passed; proposal auto-applied.'],
+      riskClassification,
+      benchmarkEvidence,
+    };
   }
 
   /**
    * Apply an approved policy change proposal
    */
-  async applyProposal(proposal: PolicyChangeProposal): Promise<void> {
+  async applyProposal(proposal: PolicyChangeProposal, actor = 'automated-pipeline'): Promise<void> {
     if (proposal.recommendationStatus !== 'approved') {
       throw new Error(`Cannot apply proposal with status: ${proposal.recommendationStatus}`);
     }
+
+    const rollbackJournalEntry: RollbackJournalEntry = {
+      entryId: `ROLLBACK-${this.generateId()}-${Date.now()}`,
+      proposalId: proposal.proposalId,
+      recordedAt: new Date().toISOString(),
+      appliedAt: new Date().toISOString(),
+      appliedBy: actor,
+      reversibleCommand:
+        'POST /api/intelligence-loop/policy-proposals/revert-latest { "reason": "<reason>" }',
+      proposalSnapshot: {
+        recommendationStatus: proposal.recommendationStatus,
+        reviewNotes: proposal.reviewNotes,
+        appliedAt: proposal.appliedAt,
+      },
+    };
+    this.appendText(
+      'BusinessDocs/intelligence-loop/policy-rollback-journal.jsonl',
+      `${JSON.stringify(rollbackJournalEntry)}\n`
+    );
 
     // Record audit trail
     const auditEntry = {
@@ -401,7 +738,7 @@ export class LessonsToPolicyService {
       proposalId: proposal.proposalId,
       action: 'applied',
       changesCount: proposal.recommendedChanges.length,
-      appliedBy: 'automated-pipeline',
+      appliedBy: actor,
     };
 
     const auditPath = `BusinessDocs/intelligence-loop/policy-application-audit.jsonl`;
@@ -411,22 +748,22 @@ export class LessonsToPolicyService {
     // Update proposal status
     proposal.recommendationStatus = 'applied';
     proposal.appliedAt = new Date().toISOString();
-    const proposalPath = `BusinessDocs/intelligence-loop/policy-proposals/${proposal.proposalId}.json`;
-    this.writeText(proposalPath, JSON.stringify(proposal, null, 2));
+    this.persistProposal(proposal);
+    this.emitAdaptationEvent({
+      proposalId: proposal.proposalId,
+      eventType: 'proposal-applied',
+      details: {
+        actor,
+        rollbackJournalEntryId: rollbackJournalEntry.entryId,
+      },
+    });
   }
 
   /**
    * Revert a previously applied proposal
    */
   async revertProposal(proposalId: string, reason: string): Promise<void> {
-    const proposalPath = `BusinessDocs/intelligence-loop/policy-proposals/${proposalId}.json`;
-    const content = this.readText(proposalPath);
-
-    if (!content) {
-      throw new Error(`Proposal not found: ${proposalId}`);
-    }
-
-    const proposal = JSON.parse(content) as PolicyChangeProposal;
+    const proposal = this.loadProposal(proposalId);
 
     // Record revert in audit trail
     const auditEntry = {
@@ -444,7 +781,37 @@ export class LessonsToPolicyService {
     // Update proposal status
     proposal.recommendationStatus = 'reverted';
     proposal.reviewNotes = `Reverted: ${reason}`;
-    this.writeText(proposalPath, JSON.stringify(proposal, null, 2));
+    this.persistProposal(proposal);
+    this.emitAdaptationEvent({
+      proposalId,
+      eventType: 'proposal-reverted',
+      details: { reason },
+    });
+  }
+
+  async revertLatestAppliedProposal(reason: string): Promise<{ proposalId: string }> {
+    const rollbackLog =
+      this.readText('BusinessDocs/intelligence-loop/policy-rollback-journal.jsonl') || '';
+    const rows = rollbackLog
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as RollbackJournalEntry);
+
+    if (rows.length === 0) {
+      throw new Error('No rollback journal entries found');
+    }
+
+    for (let index = rows.length - 1; index >= 0; index -= 1) {
+      const candidate = rows[index];
+      const proposal = this.loadProposal(candidate.proposalId);
+      if (proposal.recommendationStatus === 'applied') {
+        await this.revertProposal(candidate.proposalId, reason);
+        return { proposalId: candidate.proposalId };
+      }
+    }
+
+    throw new Error('No applied proposal found in rollback journal');
   }
 
   private generateId(): string {

--- a/src/webapp/routes/intelligence-loop.ts
+++ b/src/webapp/routes/intelligence-loop.ts
@@ -265,12 +265,54 @@ export async function registerIntelligenceLoopRoutes(app: FastifyInstance, ctx: 
    * POST /api/intelligence-loop/policy-proposals/:id/approve
    * Approve a policy proposal
    */
-  app.post<{ Params: { id: string } }>(
+  app.post<{ Params: { id: string }; Body: { reviewer?: string } }>(
     '/api/intelligence-loop/policy-proposals/:id/approve',
     async (request, reply) => {
       try {
-        // In a real implementation, would load, approve, and apply proposal
-        return reply.send({ ok: true, message: 'Policy proposal approved and applied' });
+        const proposal = await lessonsPolicyService.approveProposal(
+          request.params.id,
+          request.body?.reviewer || 'orchestrator'
+        );
+        return reply.send({ ok: true, proposal });
+      } catch (error) {
+        app.log.error({ error }, '');
+        return reply.status(400).send({ ok: false, error: (error as Error).message });
+      }
+    }
+  );
+
+  /**
+   * POST /api/intelligence-loop/policy-proposals/:id/auto-apply
+   * Auto-apply a low-risk proposal when all guard conditions pass
+   */
+  app.post<{ Params: { id: string }; Body: { actor?: string } }>(
+    '/api/intelligence-loop/policy-proposals/:id/auto-apply',
+    async (request, reply) => {
+      try {
+        const result = await lessonsPolicyService.autoApplyProposal(
+          request.params.id,
+          request.body?.actor || 'automated-pipeline'
+        );
+        return reply.send({ ok: result.autoApplied, result });
+      } catch (error) {
+        app.log.error({ error }, '');
+        return reply.status(400).send({ ok: false, error: (error as Error).message });
+      }
+    }
+  );
+
+  /**
+   * POST /api/intelligence-loop/policy-proposals/revert-latest
+   * Revert the latest applied proposal from rollback journal
+   */
+  app.post<{ Body: { reason: string } }>(
+    '/api/intelligence-loop/policy-proposals/revert-latest',
+    async (request, reply) => {
+      try {
+        const reverted = await lessonsPolicyService.revertLatestAppliedProposal(
+          request.body.reason
+        );
+        return reply.send({ ok: true, reverted });
       } catch (error) {
         app.log.error({ error }, '');
         return reply.status(400).send({ ok: false, error: (error as Error).message });

--- a/tests/unit/intelligence-loop.test.ts
+++ b/tests/unit/intelligence-loop.test.ts
@@ -161,6 +161,7 @@ describe('PATTERNS M1: Close The Intelligence Loop', () => {
       expect(proposal.proposalId).toMatch(/^POLICYCHANGE-/);
       expect(proposal.recommendedChanges.length).toBeGreaterThan(0);
       expect(proposal.recommendationStatus).toBe('pending-review');
+      expect(proposal.summary.riskClassification).toBe('low');
       expect(safeWriteCall).toHaveBeenCalled();
     });
 
@@ -229,6 +230,110 @@ describe('PATTERNS M1: Close The Intelligence Loop', () => {
       expect(proposal.summary.highRiskChanges).toBe(1);
       expect(proposal.summary.requiresApproval).toBe(2);
       expect(proposal.summary.confidenceScore).toBeGreaterThan(0.6);
+      expect(proposal.summary.riskClassification).toBe('high');
+    });
+
+    it('should auto-apply low-risk proposals when benchmark evidence passes', async () => {
+      ctx.store.writeFile(
+        'tests/load/bench-low-risk.json',
+        JSON.stringify({ p95: 1500, errorRatePct: 2, successRatePct: 98 })
+      );
+
+      const proposal = await service.createProposal(
+        [
+          {
+            id: 'LESSON-AUTOAPPLY-001',
+            category: 'routing',
+            narrative: 'Routing policy remained stable under load',
+            evidence: [],
+            confidence: 0.9,
+            applicability: { phases: [], agents: [], scope: 'universal' },
+          },
+        ],
+        ['bench-low-risk'],
+        []
+      );
+
+      const result = await service.autoApplyProposal(proposal.proposalId);
+
+      expect(result.autoApplied).toBe(true);
+      expect(result.failClosed).toBe(false);
+
+      const stored = JSON.parse(
+        ctx.store.readFile(
+          `BusinessDocs/intelligence-loop/policy-proposals/${proposal.proposalId}.json`
+        )
+      );
+      expect(stored.recommendationStatus).toBe('applied');
+
+      const rollbackJournal = ctx.store.readFile(
+        'BusinessDocs/intelligence-loop/policy-rollback-journal.jsonl'
+      );
+      expect(rollbackJournal).toContain(proposal.proposalId);
+
+      const adaptationEvents = ctx.store.readFile('BusinessDocs/metrics/adaptation-events.jsonl');
+      expect(adaptationEvents).toContain('auto-apply-attempted');
+      expect(adaptationEvents).toContain('proposal-applied');
+    });
+
+    it('should fail closed when auto-apply benchmark evidence is missing', async () => {
+      const proposal = await service.createProposal(
+        [
+          {
+            id: 'LESSON-AUTOAPPLY-002',
+            category: 'retrieval',
+            narrative: 'Retrieval profile appears stable',
+            evidence: [],
+            confidence: 0.92,
+            applicability: { phases: [], agents: [], scope: 'universal' },
+          },
+        ],
+        ['missing-benchmark'],
+        []
+      );
+
+      const result = await service.autoApplyProposal(proposal.proposalId);
+      expect(result.autoApplied).toBe(false);
+      expect(result.failClosed).toBe(true);
+      expect(result.reasons.some((reason) => reason.includes('benchmark evidence'))).toBe(true);
+
+      const adaptationEvents = ctx.store.readFile('BusinessDocs/metrics/adaptation-events.jsonl');
+      expect(adaptationEvents).toContain('auto-apply-failed-closed');
+    });
+
+    it('should revert latest applied proposal from rollback journal in one command', async () => {
+      ctx.store.writeFile(
+        'tests/load/bench-revert.json',
+        JSON.stringify({ p95: 1200, errorRatePct: 1, successRatePct: 99 })
+      );
+
+      const proposal = await service.createProposal(
+        [
+          {
+            id: 'LESSON-ROLLBACK-001',
+            category: 'tool-use',
+            narrative: 'Concurrency tuning stayed within safe boundaries',
+            evidence: [],
+            confidence: 0.91,
+            applicability: { phases: [], agents: [], scope: 'universal' },
+          },
+        ],
+        ['bench-revert'],
+        []
+      );
+
+      const applied = await service.autoApplyProposal(proposal.proposalId);
+      expect(applied.autoApplied).toBe(true);
+
+      const reverted = await service.revertLatestAppliedProposal('rapid rollback');
+      expect(reverted.proposalId).toBe(proposal.proposalId);
+
+      const stored = JSON.parse(
+        ctx.store.readFile(
+          `BusinessDocs/intelligence-loop/policy-proposals/${proposal.proposalId}.json`
+        )
+      );
+      expect(stored.recommendationStatus).toBe('reverted');
     });
 
     it('should apply and revert proposals with audit trails', async () => {

--- a/tests/unit/routes-intelligence-loop.test.ts
+++ b/tests/unit/routes-intelligence-loop.test.ts
@@ -9,6 +9,14 @@ import { registerIntelligenceLoopRoutes } from '../../src/webapp/routes/intellig
 function createContext(): ServiceContext {
   const store = new InMemoryStore();
   store.writeFile(
+    'tests/load/bench-route.json',
+    JSON.stringify({ p95: 1400, errorRatePct: 2, successRatePct: 98 })
+  );
+  store.writeFile(
+    'BusinessDocs/retrospectives/retro-route.md',
+    '# Retrospective\n\n## Successes\n- Approval workflow remained stable under guardrails\n'
+  );
+  store.writeFile(
     'Patterns/01-prompt-chaining.md',
     '# Prompt Chaining\nCurrent score: 9.2/10\nTarget score: 9.9/10\n'
   );
@@ -187,19 +195,40 @@ describe('routes/intelligence-loop', () => {
       url: '/api/intelligence-loop/policy-proposals',
       payload: {
         reevaluateArtifactIds: [],
-        retrospectiveIds: [],
-        benchmarkRunIds: [],
+        retrospectiveIds: ['retro-route.md'],
+        benchmarkRunIds: ['bench-route'],
       },
     });
     expect(proposalRes.statusCode).toBe(201);
-    expect(proposalRes.json().proposal.proposalId).toMatch(/^POLICYCHANGE-/);
+    const proposalId = proposalRes.json().proposal.proposalId as string;
+    expect(proposalId).toMatch(/^POLICYCHANGE-/);
 
     const approveRes = await app.inject({
       method: 'POST',
-      url: '/api/intelligence-loop/policy-proposals/any-id/approve',
+      url: `/api/intelligence-loop/policy-proposals/${proposalId}/approve`,
     });
     expect(approveRes.statusCode).toBe(200);
     expect(approveRes.json().ok).toBe(true);
+
+    const autoApplyRes = await app.inject({
+      method: 'POST',
+      url: `/api/intelligence-loop/policy-proposals/${proposalId}/auto-apply`,
+      payload: {
+        actor: 'route-test-runner',
+      },
+    });
+    expect(autoApplyRes.statusCode).toBe(200);
+    expect(autoApplyRes.json().result.autoApplied).toBe(true);
+
+    const revertRes = await app.inject({
+      method: 'POST',
+      url: '/api/intelligence-loop/policy-proposals/revert-latest',
+      payload: {
+        reason: 'route rollback validation',
+      },
+    });
+    expect(revertRes.statusCode).toBe(200);
+    expect(revertRes.json().reverted.proposalId).toBe(proposalId);
   });
 
   it('handles benchmark comparison and proposal listing', async () => {


### PR DESCRIPTION
## Summary
- Adds risk classification for lessons-to-policy proposals and persists it in proposal summaries.
- Implements guarded low-risk auto-apply with explicit gate predicates.
- Adds benchmark threshold enforcement by policy class.
- Fails closed when benchmark evidence is missing or thresholds fail.
- Emits adaptation lifecycle audit events for proposal creation, approval, auto-apply attempts, fail-closed outcomes, apply, and revert.
- Adds rollback journal metadata and one-command revert-latest path.
- Wires new policy endpoints in intelligence-loop routes.
- Extends unit and route tests for the new M3 policy behavior.

## Scope Mapping
- #1447 Add risk classifier for lessons-to-policy proposals
- #1448 Implement low-risk auto-apply path with guard conditions
- #1449 Add rollback journal and one-command revert path
- #1450 Define benchmark thresholds required for auto-apply
- #1451 Add adaptation audit events to observability
- #1453 Add fail-closed behavior when benchmark data is missing

## Validation
- npm run format
- npm run lint
- npm run test:coverage
- Targeted tests: tests/unit/intelligence-loop.test.ts and tests/unit/routes-intelligence-loop.test.ts