### PR TITLE
feat(ux): UX Audit — Core Workflow Polish

### DIFF
--- a/src/webapp/ui/src/components/workspaces/add-repository-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/add-repository-dialog.tsx
@@ -1,10 +1,61 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { ModalDialog } from '@/components/ui/modal-dialog';
 import { InputField } from '@/components/ui/input-field';
 import { FormRow } from '@/components/ui/form-row';
 import { AsyncMutationFeedback } from '@/components/ui/async-mutation-feedback';
 import { useAddRepository } from '@/hooks';
+
+type Provider = 'github' | 'azure-devops' | 'gitlab' | 'local';
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+}
+
+const PROVIDER_CONFIG: Record<
+  Provider,
+  {
+    locationLabel: string;
+    locationPlaceholder: string;
+    locationHelper: string;
+    urlPattern: RegExp;
+    showBranch: boolean;
+  }
+> = {
+  github: {
+    locationLabel: 'Repository URL',
+    locationPlaceholder: 'https://github.com/owner/repo',
+    locationHelper: 'Provide the full GitHub repository URL.',
+    urlPattern: /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+/,
+    showBranch: true,
+  },
+  'azure-devops': {
+    locationLabel: 'Repository URL',
+    locationPlaceholder: 'https://dev.azure.com/org/project/_git/repo',
+    locationHelper: 'Provide the full Azure DevOps Git repository URL.',
+    urlPattern: /^https:\/\/(dev\.azure\.com|[\w.-]+\.visualstudio\.com)\//,
+    showBranch: true,
+  },
+  gitlab: {
+    locationLabel: 'Repository URL',
+    locationPlaceholder: 'https://gitlab.com/owner/repo',
+    locationHelper: 'Provide the full GitLab repository URL.',
+    urlPattern: /^https:\/\/[\w.-]+\.\w+\/[\w.-]+\/[\w.-]+/,
+    showBranch: true,
+  },
+  local: {
+    locationLabel: 'Local Repository Path',
+    locationPlaceholder: 'e.g., D:/repositories/my-project',
+    locationHelper:
+      'Absolute path to an existing local Git repository. The default branch will be detected automatically.',
+    urlPattern: /^[A-Za-z]:[/\\]|^\//,
+    showBranch: false,
+  },
+};
 
 export function AddRepositoryDialog({
   open,
@@ -17,23 +68,39 @@ export function AddRepositoryDialog({
 }) {
   const addRepository = useAddRepository();
   const [repoId, setRepoId] = useState('');
+  const [idTouched, setIdTouched] = useState(false);
   const [name, setName] = useState('');
-  const [provider, setProvider] = useState<'github' | 'azure-devops' | 'gitlab' | 'local'>(
-    'github'
-  );
+  const [provider, setProvider] = useState<Provider>('github');
   const [locationValue, setLocationValue] = useState('');
   const [defaultBranch, setDefaultBranch] = useState('main');
 
-  const locationLabel = provider === 'local' ? 'Local Repository Path' : 'Repository URL';
-  const locationPlaceholder =
-    provider === 'local' ? 'e.g., D:/repositories/my-project' : 'https://github.com/owner/repo';
-  const locationHelper =
-    provider === 'local'
-      ? 'Use an absolute path to an existing local Git repository folder.'
-      : 'Provide the canonical remote repository URL.';
+  const config = PROVIDER_CONFIG[provider];
+
+  useEffect(() => {
+    if (!idTouched) {
+      setRepoId(slugify(name));
+    }
+  }, [name, idTouched]);
+
+  const locationError = useMemo(() => {
+    if (!locationValue.trim()) return undefined;
+    if (!config.urlPattern.test(locationValue.trim())) {
+      return provider === 'local'
+        ? 'Enter an absolute filesystem path (e.g. D:/repos/project).'
+        : `Enter a valid ${provider === 'azure-devops' ? 'Azure DevOps' : provider.charAt(0).toUpperCase() + provider.slice(1)} repository URL.`;
+    }
+    return undefined;
+  }, [locationValue, config.urlPattern, provider]);
+
+  const canSubmit =
+    repoId.trim() &&
+    name.trim() &&
+    locationValue.trim() &&
+    !locationError &&
+    (config.showBranch ? defaultBranch.trim() : true);
 
   const handleSubmit = useCallback(() => {
-    if (!repoId.trim() || !name.trim() || !locationValue.trim() || !defaultBranch.trim()) return;
+    if (!canSubmit) return;
 
     addRepository.mutate(
       {
@@ -43,13 +110,14 @@ export function AddRepositoryDialog({
           name: name.trim(),
           provider,
           url: locationValue.trim(),
-          defaultBranch: defaultBranch.trim(),
+          defaultBranch: config.showBranch ? defaultBranch.trim() : 'auto',
         },
       },
       {
         onSuccess: () => {
           onOpenChange(false);
           setRepoId('');
+          setIdTouched(false);
           setName('');
           setProvider('github');
           setLocationValue('');
@@ -59,11 +127,13 @@ export function AddRepositoryDialog({
     );
   }, [
     addRepository,
+    canSubmit,
     repoId,
     name,
     provider,
     locationValue,
     defaultBranch,
+    config.showBranch,
     workspaceId,
     onOpenChange,
   ]);
@@ -82,13 +152,7 @@ export function AddRepositoryDialog({
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={
-              !repoId.trim() ||
-              !name.trim() ||
-              !locationValue.trim() ||
-              !defaultBranch.trim() ||
-              addRepository.isPending
-            }
+            disabled={!canSubmit || addRepository.isPending}
             loading={addRepository.isPending}
           >
             Add repository
@@ -104,18 +168,14 @@ export function AddRepositoryDialog({
           errorMessagePrefix="Adding repository failed."
           onRetry={handleSubmit}
         />
-        <InputField
-          label="Repository ID"
-          value={repoId}
-          onChange={(e) => setRepoId(e.target.value)}
-          placeholder="e.g., repo-frontend"
-        />
-        <InputField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
         <FormRow label="Provider">
           <select
             className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
             value={provider}
-            onChange={(e) => setProvider(e.target.value as typeof provider)}
+            onChange={(e) => {
+              setProvider(e.target.value as Provider);
+              setLocationValue('');
+            }}
             aria-label="Repository provider"
           >
             <option value="github">GitHub</option>
@@ -125,18 +185,38 @@ export function AddRepositoryDialog({
           </select>
         </FormRow>
         <InputField
-          label={locationLabel}
-          helperText={locationHelper}
-          value={locationValue}
-          onChange={(e) => setLocationValue(e.target.value)}
-          placeholder={locationPlaceholder}
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g., Frontend App"
+          helperText="Display name used in the workspace sidebar and reports."
         />
         <InputField
-          label="Default Branch"
-          value={defaultBranch}
-          onChange={(e) => setDefaultBranch(e.target.value)}
-          placeholder="main"
+          label="Repository ID"
+          value={repoId}
+          onChange={(e) => {
+            setIdTouched(true);
+            setRepoId(e.target.value);
+          }}
+          placeholder="e.g., frontend-app"
+          helperText="Machine-readable identifier auto-generated from the name."
         />
+        <InputField
+          label={config.locationLabel}
+          helperText={locationError ? undefined : config.locationHelper}
+          error={locationError}
+          value={locationValue}
+          onChange={(e) => setLocationValue(e.target.value)}
+          placeholder={config.locationPlaceholder}
+        />
+        {config.showBranch && (
+          <InputField
+            label="Default Branch"
+            value={defaultBranch}
+            onChange={(e) => setDefaultBranch(e.target.value)}
+            placeholder="main"
+          />
+        )}
       </div>
     </ModalDialog>
   );

--- a/src/webapp/ui/src/components/workspaces/create-project-dialog.tsx
+++ b/src/webapp/ui/src/components/workspaces/create-project-dialog.tsx
@@ -1,9 +1,17 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { ModalDialog } from '@/components/ui/modal-dialog';
 import { InputField } from '@/components/ui/input-field';
 import { AsyncMutationFeedback } from '@/components/ui/async-mutation-feedback';
 import { useCreateProject } from '@/hooks';
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+}
 
 export function CreateProjectDialog({
   open,
@@ -17,6 +25,13 @@ export function CreateProjectDialog({
   const createProject = useCreateProject();
   const [projectId, setProjectId] = useState('');
   const [name, setName] = useState('');
+  const [idTouched, setIdTouched] = useState(false);
+
+  useEffect(() => {
+    if (!idTouched) {
+      setProjectId(slugify(name));
+    }
+  }, [name, idTouched]);
 
   const handleSubmit = useCallback(() => {
     if (!projectId.trim() || !name.trim()) return;
@@ -34,6 +49,7 @@ export function CreateProjectDialog({
           onOpenChange(false);
           setProjectId('');
           setName('');
+          setIdTouched(false);
         },
       }
     );
@@ -70,16 +86,21 @@ export function CreateProjectDialog({
           onRetry={handleSubmit}
         />
         <InputField
-          label="Project ID"
-          value={projectId}
-          onChange={(e) => setProjectId(e.target.value)}
-          placeholder="e.g., proj-data-pipeline"
-        />
-        <InputField
           label="Project Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="Project name"
+          placeholder="e.g., My Data Pipeline"
+          helperText="Give the project a recognizable name used in the UI and reports."
+        />
+        <InputField
+          label="Project ID"
+          value={projectId}
+          onChange={(e) => {
+            setIdTouched(true);
+            setProjectId(e.target.value);
+          }}
+          placeholder="e.g., my-data-pipeline"
+          helperText="Machine-readable identifier auto-generated from the name. Edit only if you need a specific slug."
         />
       </div>
     </ModalDialog>

--- a/src/webapp/ui/src/pages/commands/commands-page.test.tsx
+++ b/src/webapp/ui/src/pages/commands/commands-page.test.tsx
@@ -37,8 +37,8 @@ describe('CommandsPage', () => {
 
   it('renders explicit guidance for how to proceed', async () => {
     await renderPage();
-    expect(screen.getByText(/how to proceed/i)).toBeInTheDocument();
     expect(screen.getByText(/recommended next step/i)).toBeInTheDocument();
+    expect(screen.getByText(/show step-by-step guide/i)).toBeInTheDocument();
     expect(screen.getByText(/what happens when you click submit brief/i)).toBeInTheDocument();
   });
 

--- a/src/webapp/ui/src/pages/commands/commands-page.tsx
+++ b/src/webapp/ui/src/pages/commands/commands-page.tsx
@@ -3,6 +3,7 @@
  * Renamed from Command Center (M15-031).
  * Refactored to thin container (P1-UI-E1-I1).
  */
+import { useState } from 'react';
 import { Text } from '@/components/ui/typography';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
@@ -15,7 +16,7 @@ import { QuickActionsSection } from './quick-actions-section';
 import { getCommandVariant, QUICK_ACTIONS } from './commands-config';
 import { ProjectBriefSection } from './project-brief-section';
 import { CommandQueueSection } from './command-queue-section';
-import { Sparkles, ClipboardList, Radar } from 'lucide-react';
+import { ClipboardList, Radar, ChevronDown, ChevronUp } from 'lucide-react';
 
 function getRecommendedAction(hasBrief: boolean, quickActions: typeof QUICK_ACTIONS) {
   if (quickActions.length === 0) {
@@ -50,6 +51,8 @@ export default function CommandsPage() {
     handleQuickAction,
     handleSubmitBrief,
   } = useCommandsController();
+
+  const [showSteps, setShowSteps] = useState(false);
 
   const recommendedAction = getRecommendedAction(hasBrief, quickActions);
 
@@ -144,16 +147,42 @@ export default function CommandsPage() {
 
         <ContextStrip items={contextItems} />
 
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
-          <Card elevation="flat" className="border border-border/70 px-5 py-5">
-            <div className="flex items-start gap-3">
-              <Sparkles className="mt-0.5 size-5 text-info" />
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-semibold">How to proceed</span>
-                  <Badge variant="outline">3 steps</Badge>
+        <Card elevation="flat" className="border border-border/70 px-5 py-5">
+          <div className="flex items-start gap-3">
+            <ClipboardList className="mt-0.5 size-5 text-warning" />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-semibold">Recommended next step</span>
+                <Badge variant="warning">{guidanceStep.badge}</Badge>
+              </div>
+              <div className="mt-3 text-sm font-medium">{guidanceStep.title}</div>
+              <Text muted className="mt-1 text-sm">
+                {guidanceStep.description}
+              </Text>
+              <div className="mt-4 rounded-2xl border border-border/70 bg-background/70 p-4">
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  <Radar className="size-3.5" /> Suggested command
                 </div>
-                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <div className="mt-2 flex items-center gap-2">
+                  <Badge variant={getCommandVariant(recommendedAction.command)}>
+                    {recommendedAction.label}
+                  </Badge>
+                  <span className="text-sm font-medium">{recommendedAction.description}</span>
+                </div>
+                <Text muted className="mt-2 text-xs">
+                  {recommendedAction.nextStep}
+                </Text>
+              </div>
+              <button
+                type="button"
+                className="mt-4 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setShowSteps((prev) => !prev)}
+              >
+                {showSteps ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+                {showSteps ? 'Hide step-by-step guide' : 'Show step-by-step guide'}
+              </button>
+              {showSteps && (
+                <div className="mt-3 grid gap-3 md:grid-cols-3">
                   <div className="rounded-2xl border border-border/70 bg-background/70 p-4">
                     <Badge variant="secondary">1</Badge>
                     <div className="mt-3 font-medium">Name the work</div>
@@ -179,40 +208,10 @@ export default function CommandsPage() {
                     </Text>
                   </div>
                 </div>
-              </div>
+              )}
             </div>
-          </Card>
-
-          <Card elevation="flat" className="border border-border/70 px-5 py-5">
-            <div className="flex items-start gap-3">
-              <ClipboardList className="mt-0.5 size-5 text-warning" />
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-semibold">Recommended next step</span>
-                  <Badge variant="warning">{guidanceStep.badge}</Badge>
-                </div>
-                <div className="mt-3 text-sm font-medium">{guidanceStep.title}</div>
-                <Text muted className="mt-1 text-sm">
-                  {guidanceStep.description}
-                </Text>
-                <div className="mt-4 rounded-2xl border border-border/70 bg-background/70 p-4">
-                  <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                    <Radar className="size-3.5" /> Suggested command
-                  </div>
-                  <div className="mt-2 flex items-center gap-2">
-                    <Badge variant={getCommandVariant(recommendedAction.command)}>
-                      {recommendedAction.label}
-                    </Badge>
-                    <span className="text-sm font-medium">{recommendedAction.description}</span>
-                  </div>
-                  <Text muted className="mt-2 text-xs">
-                    {recommendedAction.nextStep}
-                  </Text>
-                </div>
-              </div>
-            </div>
-          </Card>
-        </div>
+          </div>
+        </Card>
 
         <ProjectBriefSection
           projectName={projectName}

--- a/src/webapp/ui/src/pages/sessions/sessions-page.tsx
+++ b/src/webapp/ui/src/pages/sessions/sessions-page.tsx
@@ -2,6 +2,7 @@
  * Sessions page — list all orchestrator sessions with status and progress.
  * M15 / Issue #M15-028
  */
+import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Text } from '@/components/ui/typography';
 import { Card } from '@/components/ui/card';
@@ -15,10 +16,28 @@ import { PageHeader } from '@/components/layout/page-header';
 import { ContextStrip, type ContextStripItem } from '@/components/layout/context-strip';
 import { PageShell } from '@/components/ui/page-shell';
 import { QueueTriageList, type QueueTriageItem } from '@/components/ui/queue-triage-list';
-import { useSessions } from '@/hooks';
+import {
+  useSessions,
+  usePauseOrchestrator,
+  useResumeOrchestrator,
+  useOrchestratorStop,
+} from '@/hooks';
 import { PageHelpStrip } from '@/components/help-panel/page-help-strip';
 import type { SessionStatus } from '@/lib/api-types';
-import { Activity, ArrowRight, CheckCircle, Clock, Pause, Sparkles, XCircle } from 'lucide-react';
+import {
+  Activity,
+  ArrowRight,
+  CheckCircle,
+  Clock,
+  Pause,
+  Play,
+  Sparkles,
+  Square,
+  XCircle,
+} from 'lucide-react';
+
+type StatusFilter = 'all' | SessionStatus;
+type SortKey = 'newest' | 'oldest' | 'progress-desc' | 'progress-asc' | 'status';
 
 const statusConfig: Record<
   SessionStatus,
@@ -88,11 +107,63 @@ function getSessionGuidance(
   };
 }
 
+const STATUS_SORT_PRIORITY: Record<SessionStatus, number> = {
+  active: 0,
+  paused: 1,
+  failed: 2,
+  completed: 3,
+};
+
+const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: 'newest', label: 'Newest first' },
+  { value: 'oldest', label: 'Oldest first' },
+  { value: 'progress-desc', label: 'Progress (high → low)' },
+  { value: 'progress-asc', label: 'Progress (low → high)' },
+  { value: 'status', label: 'Status priority' },
+];
+
+const FILTER_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'paused', label: 'Paused' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'completed', label: 'Completed' },
+];
+
 export default function SessionsPage() {
   const { data, isLoading, error, refetch } = useSessions();
   const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [sortKey, setSortKey] = useState<SortKey>('newest');
 
-  const sessions = data?.sessions ?? [];
+  const pauseMutation = usePauseOrchestrator();
+  const resumeMutation = useResumeOrchestrator();
+  const stopMutation = useOrchestratorStop();
+
+  const sessions = useMemo(() => data?.sessions ?? [], [data?.sessions]);
+
+  const filteredSessions = useMemo(() => {
+    let list =
+      statusFilter === 'all' ? sessions : sessions.filter((s) => s.status === statusFilter);
+
+    list = [...list].sort((a, b) => {
+      switch (sortKey) {
+        case 'oldest':
+          return new Date(a.started_at).getTime() - new Date(b.started_at).getTime();
+        case 'progress-desc':
+          return b.progress - a.progress;
+        case 'progress-asc':
+          return a.progress - b.progress;
+        case 'status':
+          return STATUS_SORT_PRIORITY[a.status] - STATUS_SORT_PRIORITY[b.status];
+        case 'newest':
+        default:
+          return new Date(b.started_at).getTime() - new Date(a.started_at).getTime();
+      }
+    });
+
+    return list;
+  }, [sessions, statusFilter, sortKey]);
   const nextStep = getSessionGuidance(sessions);
   const activeSessions = sessions.filter((session) => session.status === 'active').length;
   const completedSessions = sessions.filter((session) => session.status === 'completed').length;
@@ -361,8 +432,46 @@ export default function SessionsPage() {
           headingLevel={2}
         />
 
+        {/* Session filter and sort controls */}
+        <div
+          className="flex flex-wrap items-center justify-between gap-3"
+          role="toolbar"
+          aria-label="Session filters"
+        >
+          <div className="flex flex-wrap gap-1" role="tablist" aria-label="Filter by status">
+            {FILTER_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                role="tab"
+                aria-selected={statusFilter === tab.value}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  statusFilter === tab.value
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+                onClick={() => setStatusFilter(tab.value)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <select
+            value={sortKey}
+            onChange={(e) => setSortKey(e.target.value as SortKey)}
+            aria-label="Sort sessions"
+            className="rounded-md border border-input bg-background px-3 py-1 text-xs"
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         {/* Session list */}
-        {sessions.length === 0 ? (
+        {filteredSessions.length === 0 ? (
           <EmptyState
             icon={<Activity className="size-8" />}
             title="No sessions"
@@ -370,7 +479,7 @@ export default function SessionsPage() {
           />
         ) : (
           <div className="space-y-3">
-            {sessions.map((session) => {
+            {filteredSessions.map((session) => {
               const config = statusConfig[session.status];
               const activeAgents = getActiveAgents(session);
               const activeAgentsLabel = formatActiveAgentsLabel(activeAgents);
@@ -412,6 +521,53 @@ export default function SessionsPage() {
                       {activeAgents.length > 1 ? 'Current agents: ' : 'Current agent: '}
                       <span className="font-medium">{activeAgentsLabel}</span>
                     </p>
+                  )}
+                  {(session.status === 'active' || session.status === 'paused') && (
+                    <div
+                      className="mt-2 flex items-center gap-2"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {session.status === 'active' ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          disabled={pauseMutation.isPending}
+                          onClick={() =>
+                            pauseMutation.mutate({
+                              rationale: 'Paused from sessions list',
+                              requested_by: 'operator-ui',
+                            })
+                          }
+                        >
+                          <Pause className="mr-1 size-3" /> Pause
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          disabled={resumeMutation.isPending}
+                          onClick={() =>
+                            resumeMutation.mutate({
+                              rationale: 'Resumed from sessions list',
+                              requested_by: 'operator-ui',
+                            })
+                          }
+                        >
+                          <Play className="mr-1 size-3" /> Resume
+                        </Button>
+                      )}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-7 text-xs text-destructive hover:text-destructive"
+                        disabled={stopMutation.isPending}
+                        onClick={() => stopMutation.mutate()}
+                      >
+                        <Square className="mr-1 size-3" /> Cancel
+                      </Button>
+                    </div>
                   )}
                 </Card>
               );


### PR DESCRIPTION
## UX Audit — Core Workflow Polish

Implements all 5 issues from the **UX Audit - Core Workflow Polish** milestone.

### Changes

#### EPIC UX-E3: Workspace and Project CRUD Clarity (#1543)
- **#1545 — Project creation requires opaque ID input without clear rationale**
  Auto-generate Project ID from name using `slugify()`. Moved Name field first, ID second with helper text. Manual ID edits are preserved.

- **#1546 — Repository form does not adapt fields and validation by provider**
  Added `PROVIDER_CONFIG` with per-provider URL patterns, labels, placeholders, and validation. Hides Default Branch for local provider. Auto-generates repo ID from name. Real-time URL validation feedback.

#### EPIC UX-E4: Runtime Flow Comprehension (#1544)
- **#1547 — Commands page presents competing next-step narratives and dense guidance**
  Consolidated two competing guidance cards into a single "Recommended next step" card with a collapsible "Show step-by-step guide" toggle.

- **#1548 — Sessions page lacks sorting and filtering controls for triage**
  Added filter tabs (All / Active / Paused / Completed / Failed) and a sort dropdown (Newest first, Oldest first, Progress ↓/↑, Status priority).

- **#1549 — No direct cancel/pause controls on primary active-run surfaces**
  Added inline Pause/Resume and Cancel buttons on active/paused session cards in the sessions list.

### Quality Gates
- ✅ `npm run format` — passed
- ✅ `npm run lint` — 0 errors, 0 warnings
- ✅ Unit tests — 40/40 passed
- ✅ `npm run test:coverage` — passed (2 pre-existing failures in e2e-api-flows only)

Closes #1545, #1546, #1547, #1548, #1549