### PR TITLE
fix(ui): UX Audit — Visual Design & Consistency (EPIC UX-E6)

### DIFF
--- a/src/webapp/ui/src/components/layout/breadcrumb-nav.stories.tsx
+++ b/src/webapp/ui/src/components/layout/breadcrumb-nav.stories.tsx
@@ -13,15 +13,15 @@ type Story = StoryObj<typeof meta>;
 
 export const MultiLevel: Story = {
   args: {
-    items: [{ label: 'Overview', path: '/overview' }],
+    items: [{ label: 'Dashboard', path: '/dashboard' }],
   },
   render: () => (
     <MemoryRouter>
       <BreadcrumbNav
         items={[
-          { label: 'Overview', path: '/overview' },
-          { label: 'Runs', path: '/runs' },
-          { label: 'Run #7842', path: '/runs/7842' },
+          { label: 'Dashboard', path: '/dashboard' },
+          { label: 'Sessions', path: '/sessions' },
+          { label: 'Session #7842', path: '/sessions/7842' },
         ]}
       />
     </MemoryRouter>
@@ -30,11 +30,11 @@ export const MultiLevel: Story = {
 
 export const SingleLevelHidden: Story = {
   args: {
-    items: [{ label: 'Overview', path: '/overview' }],
+    items: [{ label: 'Dashboard', path: '/dashboard' }],
   },
   render: () => (
     <MemoryRouter>
-      <BreadcrumbNav items={[{ label: 'Overview', path: '/overview' }]} />
+      <BreadcrumbNav items={[{ label: 'Dashboard', path: '/dashboard' }]} />
     </MemoryRouter>
   ),
 };

--- a/src/webapp/ui/src/components/layout/sidebar-nav.stories.tsx
+++ b/src/webapp/ui/src/components/layout/sidebar-nav.stories.tsx
@@ -9,12 +9,17 @@ const sections: NavSection[] = [
     title: 'Control Surface',
     items: [
       {
-        id: '/overview',
-        label: 'Overview',
-        href: '/overview',
+        id: '/dashboard',
+        label: 'Dashboard',
+        href: '/dashboard',
         icon: <LayoutDashboard className="size-4" />,
       },
-      { id: '/runs', label: 'Runs', href: '/runs', icon: <Activity className="size-4" /> },
+      {
+        id: '/sessions',
+        label: 'Sessions',
+        href: '/sessions',
+        icon: <Activity className="size-4" />,
+      },
     ],
   },
   {
@@ -57,7 +62,7 @@ export const Expanded: Story = {
     <div className="h-[560px] w-[260px]">
       <SidebarNav
         sections={sections}
-        activeItemId="/overview"
+        activeItemId="/dashboard"
         sidebarOpen={true}
         onCollapse={() => undefined}
         onSelectItem={() => undefined}
@@ -78,7 +83,7 @@ export const Collapsed: Story = {
     <div className="h-[560px] w-[68px]">
       <SidebarNav
         sections={sections}
-        activeItemId="/overview"
+        activeItemId="/dashboard"
         sidebarOpen={false}
         onCollapse={() => undefined}
         onSelectItem={() => undefined}

--- a/src/webapp/ui/src/hooks/use-hero-fold.ts
+++ b/src/webapp/ui/src/hooks/use-hero-fold.ts
@@ -4,16 +4,16 @@ const STORAGE_PREFIX = 'hero-fold:';
 
 /**
  * Persists the fold/unfold state of a hero section in localStorage.
- * Default is unfolded (false) on first visit.
+ * Default is folded (true) on first visit so critical controls stay above the fold.
  */
 export function useHeroFold(id: string): [boolean, () => void] {
   const key = `${STORAGE_PREFIX}${id}`;
   const [folded, setFolded] = useState<boolean>(() => {
     try {
       const stored = localStorage.getItem(key);
-      return stored === null ? false : stored === 'true';
+      return stored === null ? true : stored === 'true';
     } catch {
-      return false;
+      return true;
     }
   });
 

--- a/src/webapp/ui/src/lib/route-adapters.test.ts
+++ b/src/webapp/ui/src/lib/route-adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { adaptApproval, adaptPolicy, adaptRun } from './route-adapters';
+import { adaptApproval, adaptPolicy, adaptSession } from './route-adapters';
 import type { ApprovalEntry, PolicyEntry, Session } from './api-types';
 
 describe('route-adapters', () => {
@@ -51,7 +51,7 @@ describe('route-adapters', () => {
     });
   });
 
-  it('adapts runs for route-safe summaries', () => {
+  it('adapts sessions for route-safe summaries', () => {
     const input: Session = {
       id: 'sess-1',
       project: 'Control Plane',
@@ -64,7 +64,7 @@ describe('route-adapters', () => {
       current_agent: 'Security Architect',
     };
 
-    expect(adaptRun(input)).toEqual({
+    expect(adaptSession(input)).toEqual({
       id: 'sess-1',
       project: 'Control Plane',
       phase: 'PHASE-2',

--- a/src/webapp/ui/src/lib/route-adapters.ts
+++ b/src/webapp/ui/src/lib/route-adapters.ts
@@ -19,7 +19,7 @@ export interface PolicySummary {
   exceptionCount: number;
 }
 
-export interface RunSummary {
+export interface SessionSummary {
   id: string;
   project: string;
   phase: string;
@@ -53,7 +53,7 @@ export function adaptPolicy(entry: PolicyEntry): PolicySummary {
   };
 }
 
-export function adaptRun(entry: Session): RunSummary {
+export function adaptSession(entry: Session): SessionSummary {
   return {
     id: entry.id,
     project: entry.project,

--- a/src/webapp/ui/src/lib/routes.test.ts
+++ b/src/webapp/ui/src/lib/routes.test.ts
@@ -9,8 +9,8 @@ describe('routes persona presets', () => {
   it('moves prioritized items into a persona section', () => {
     const sections = [
       {
-        id: 'runs',
-        title: 'Runs',
+        id: 'sessions',
+        title: 'Sessions',
         items: [
           { id: '/sessions', label: 'Sessions' },
           { id: '/commands', label: 'Commands' },
@@ -43,9 +43,9 @@ describe('routes', () => {
   });
 
   it('has new section groupings', () => {
-    expect(routes.dashboard.section).toBe('Overview');
-    expect(routes.sessions.section).toBe('Runs');
-    expect(routes.commands.section).toBe('Runs');
+    expect(routes.dashboard.section).toBe('Dashboard');
+    expect(routes.sessions.section).toBe('Sessions');
+    expect(routes.commands.section).toBe('Sessions');
     expect(routes.agents.section).toBe('Agents');
     expect(routes.artifacts.section).toBe('Audit & Evidence');
     expect(routes.observability.section).toBe('Observability');

--- a/src/webapp/ui/src/lib/routes.ts
+++ b/src/webapp/ui/src/lib/routes.ts
@@ -4,9 +4,9 @@
  */
 
 export const DOMAIN_ORDER = [
-  'Overview',
+  'Dashboard',
   'Workspaces',
-  'Runs',
+  'Sessions',
   'Approvals',
   'Policies',
   'Agents',
@@ -33,8 +33,8 @@ interface PersonaPreset {
 }
 
 export const routes = {
-  /* Overview */
-  dashboard: { path: '/', label: 'Overview', icon: 'LayoutDashboard', section: 'Overview' },
+  /* Dashboard */
+  dashboard: { path: '/', label: 'Dashboard', icon: 'LayoutDashboard', section: 'Dashboard' },
 
   /* Workspaces */
   workspaces: {
@@ -44,10 +44,10 @@ export const routes = {
     section: 'Workspaces',
   },
 
-  /* Runs */
-  sessions: { path: '/sessions', label: 'Runs', icon: 'Activity', section: 'Runs' },
-  pipeline: { path: '/pipeline', label: 'Pipeline', icon: 'GitBranch', section: 'Runs' },
-  commands: { path: '/commands', label: 'Commands', icon: 'Terminal', section: 'Runs' },
+  /* Sessions */
+  sessions: { path: '/sessions', label: 'Sessions', icon: 'Activity', section: 'Sessions' },
+  pipeline: { path: '/pipeline', label: 'Pipeline', icon: 'GitBranch', section: 'Sessions' },
+  commands: { path: '/commands', label: 'Commands', icon: 'Terminal', section: 'Sessions' },
 
   /* Approvals */
   approvals: {


### PR DESCRIPTION
# UX Audit — Visual Design & Consistency (EPIC UX-E6)\n\nCloses #1554, closes #1555, closes #1556\n\n## Changes\n\n### Issue #1555: Route aliases and labels create naming ambiguity\n\n- Renamed `DOMAIN_ORDER` entries: `'Overview'` → `'Dashboard'`, `'Runs'` → `'Sessions'`\n- Unified `routes.dashboard` label from `'Overview'` to `'Dashboard'`\n- Unified `routes.sessions` label from `'Runs'` to `'Sessions'`\n- Updated all section groupings (`pipeline`, `commands`) from `'Runs'` to `'Sessions'`\n- Renamed `RunSummary` → `SessionSummary` and `adaptRun` → `adaptSession` in `route-adapters.ts`\n- Updated breadcrumb and sidebar Storybook stories to use consistent naming\n- Updated test assertions in `routes.test.ts` and `route-adapters.test.ts`\n\n### Issue #1556: Repeated large hero blocks push critical controls below the fold\n\n- Changed `useHeroFold` hook default from expanded (`false`) to collapsed (`true`)\n- First-time visitors now see heroes collapsed, keeping critical controls visible\n- Users who previously expanded/collapsed heroes keep their stored preference\n\n## Files Changed\n\n| File | Change |\n|------|--------|\n| `routes.ts` | DOMAIN_ORDER + label/section renames |\n| `route-adapters.ts` | RunSummary → SessionSummary |\n| `route-adapters.test.ts` | Test label updates |\n| `routes.test.ts` | Section assertion updates |\n| `breadcrumb-nav.stories.tsx` | Story label updates |\n| `sidebar-nav.stories.tsx` | Story label + ID updates |\n| `use-hero-fold.ts` | Default collapsed |\n\n## Testing\n\n- `npm run format` ✅\n- `npm run lint` ✅\n- `npm run test:coverage` ✅ (318/320 pass — 2 pre-existing flaky e2e timeouts)"