### PR TITLE
fix(a11y): UX Audit — Accessibility & Inclusivity (EPIC UX-E7)

### DIFF
--- a/src/webapp/ui/src/components/chat/chat-panel.tsx
+++ b/src/webapp/ui/src/components/chat/chat-panel.tsx
@@ -169,6 +169,7 @@ export function ChatPanel() {
                 variant="outline"
                 onClick={onClearSession}
                 title="Clear session"
+                aria-label="Clear session"
               >
                 <Trash2 className="size-3.5" />
               </Button>
@@ -177,6 +178,7 @@ export function ChatPanel() {
                 variant="outline"
                 onClick={() => setChatOpen(false)}
                 title="Close chat"
+                aria-label="Close chat"
               >
                 <X className="size-3.5" />
               </Button>

--- a/src/webapp/ui/src/components/help-panel/help-panel.test.tsx
+++ b/src/webapp/ui/src/components/help-panel/help-panel.test.tsx
@@ -94,4 +94,25 @@ describe('HelpPanel', () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('moves focus into the drawer on mount', () => {
+    renderPanel(['/commands']);
+    const dialog = screen.getByRole('dialog', { name: /page help drawer/i });
+    expect(dialog).toHaveFocus();
+  });
+
+  it('traps focus within the drawer on Tab', async () => {
+    renderPanel(['/commands']);
+    const user = userEvent.setup();
+    const dialog = screen.getByRole('dialog', { name: /page help drawer/i });
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled])'
+    );
+    const lastFocusable = focusable[focusable.length - 1];
+
+    // Focus last element, then Tab should wrap to first
+    lastFocusable.focus();
+    await user.tab();
+    expect(focusable[0]).toHaveFocus();
+  });
 });

--- a/src/webapp/ui/src/components/help-panel/help-panel.tsx
+++ b/src/webapp/ui/src/components/help-panel/help-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useCallback, useState } from 'react';
+import { useEffect, useMemo, useCallback, useState, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { X, BookOpenText, Link2, ListTree, Loader2, Search } from 'lucide-react';
@@ -18,6 +18,8 @@ interface HelpPanelProps {
 export function HelpPanel({ onClose }: HelpPanelProps) {
   const location = useLocation();
   const [searchQuery, setSearchQuery] = useState('');
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
   const helpRouteSlug = useUIStore((s) => s.helpRouteSlug);
   const helpTopicId = useUIStore((s) => s.helpTopicId);
   const setHelpTopic = useUIStore((s) => s.setHelpTopic);
@@ -40,12 +42,42 @@ export function HelpPanel({ onClose }: HelpPanelProps) {
   const pageSearchResults = searchData?.results.filter((entry) => entry.kind === 'page') ?? [];
   const topicSearchResults = searchData?.results.filter((entry) => entry.kind === 'topic') ?? [];
 
-  // Close on Escape
+  // Capture trigger, move focus into the drawer, and restore on close
   useEffect(() => {
+    triggerRef.current = document.activeElement;
+    drawerRef.current?.focus();
+    return () => {
+      (triggerRef.current as HTMLElement | null)?.focus?.();
+    };
+  }, []);
+
+  // Focus trap + Escape to close
+  useEffect(() => {
+    const drawer = drawerRef.current;
+    if (!drawer) return;
+
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         e.preventDefault();
         onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const focusable = drawer!.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
       }
     }
     document.addEventListener('keydown', handleKey);
@@ -61,11 +93,13 @@ export function HelpPanel({ onClose }: HelpPanelProps) {
 
   return (
     <div
+      ref={drawerRef}
       className="fixed inset-0 z-50 flex justify-end bg-black/45"
       onClick={handleBackdropClick}
       role="dialog"
       aria-label="Page help drawer"
       aria-modal="true"
+      tabIndex={-1}
     >
       <aside className="flex h-full w-full max-w-3xl animate-in slide-in-from-right-8 duration-200 border-l border-border bg-card/95 shadow-2xl backdrop-blur">
         <div className="flex min-w-0 flex-1 flex-col">

--- a/src/webapp/ui/src/components/onboarding/welcome-wizard.test.tsx
+++ b/src/webapp/ui/src/components/onboarding/welcome-wizard.test.tsx
@@ -21,10 +21,12 @@ function renderWizard(onDismiss = vi.fn()) {
 }
 
 describe('WelcomeWizard', () => {
-  it('renders the wizard dialog', () => {
+  it('renders the wizard dialog with aria-modal true', () => {
     renderWizard();
     expect(screen.getByTestId('welcome-wizard')).toBeInTheDocument();
-    expect(screen.getByRole('dialog', { name: /welcome wizard/i })).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog', { name: /welcome wizard/i });
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
   });
 
   it('shows step 1 of 5 initially', () => {
@@ -109,6 +111,35 @@ describe('WelcomeWizard', () => {
     renderWizard();
     expect(screen.queryByRole('button', { name: /go to commands/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /view sessions/i })).not.toBeInTheDocument();
+  });
+
+  it('moves focus into the dialog on mount', () => {
+    renderWizard();
+    const dialog = screen.getByRole('dialog', { name: /welcome wizard/i });
+    expect(dialog).toHaveFocus();
+  });
+
+  it('closes on Escape key', async () => {
+    const onDismiss = vi.fn();
+    renderWizard(onDismiss);
+    const user = userEvent.setup();
+    await user.keyboard('{Escape}');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('traps focus within the dialog on Tab', async () => {
+    renderWizard();
+    const user = userEvent.setup();
+    const dialog = screen.getByRole('dialog', { name: /welcome wizard/i });
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled])'
+    );
+    const lastFocusable = focusable[focusable.length - 1];
+
+    // Focus the last element, then Tab should wrap to first
+    lastFocusable.focus();
+    await user.tab();
+    expect(focusable[0]).toHaveFocus();
   });
 });
 

--- a/src/webapp/ui/src/components/onboarding/welcome-wizard.tsx
+++ b/src/webapp/ui/src/components/onboarding/welcome-wizard.tsx
@@ -3,7 +3,7 @@
  * Dismissible, persists dismissal in localStorage.
  * M15-040
  */
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -76,9 +76,55 @@ interface WelcomeWizardProps {
 export function WelcomeWizard({ onDismiss }: WelcomeWizardProps) {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(0);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
   const step = STEPS[currentStep];
   const isFirst = currentStep === 0;
   const isLast = currentStep === STEPS.length - 1;
+
+  // Capture the element that was focused before the wizard opened,
+  // move focus into the dialog, and restore focus on dismiss.
+  useEffect(() => {
+    triggerRef.current = document.activeElement;
+    dialogRef.current?.focus();
+    return () => {
+      (triggerRef.current as HTMLElement | null)?.focus?.();
+    };
+  }, []);
+
+  // Trap focus inside the dialog
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onDismiss();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const focusable = dialog!.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onDismiss]);
 
   const handleNext = useCallback(() => {
     if (isLast) {
@@ -93,7 +139,14 @@ export function WelcomeWizard({ onDismiss }: WelcomeWizardProps) {
   }, []);
 
   return (
-    <div role="dialog" aria-label="Welcome wizard" aria-modal="false" data-testid="welcome-wizard">
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-label="Welcome wizard"
+      aria-modal="true"
+      tabIndex={-1}
+      data-testid="welcome-wizard"
+    >
       <Card elevation="raised" className="p-6 max-w-lg mx-auto">
         {/* Header with dismiss */}
         <div className="flex items-center justify-between mb-4">

--- a/src/webapp/ui/src/components/workspaces/projects-section.tsx
+++ b/src/webapp/ui/src/components/workspaces/projects-section.tsx
@@ -76,6 +76,7 @@ export function ProjectsSection({
                 variant="ghost"
                 className="text-destructive hover:bg-destructive/10"
                 onClick={() => setSelectedForDeletion(project)}
+                aria-label={`Delete ${project.name}`}
               >
                 <Trash2 className="size-4" />
               </Button>

--- a/src/webapp/ui/src/components/workspaces/repositories-section.tsx
+++ b/src/webapp/ui/src/components/workspaces/repositories-section.tsx
@@ -72,6 +72,7 @@ export function RepositoriesSection({
                 variant="ghost"
                 className="text-destructive hover:bg-destructive/10"
                 onClick={() => setSelectedForRemoval(repo)}
+                aria-label={`Remove ${repo.name}`}
               >
                 <Trash2 className="size-4" />
               </Button>

--- a/src/webapp/ui/src/pages/mcp/mcp-overrides-page.tsx
+++ b/src/webapp/ui/src/pages/mcp/mcp-overrides-page.tsx
@@ -337,6 +337,7 @@ export default function McpOverridesPage() {
                           onClick={() => expireOverride.mutate(override.id)}
                           disabled={expireOverride.isPending}
                           title="Expire override"
+                          aria-label={`Expire override ${override.toolName}`}
                         >
                           <Trash2 className="size-3.5" />
                         </Button>

--- a/src/webapp/ui/src/pages/workspaces/workspaces-page.tsx
+++ b/src/webapp/ui/src/pages/workspaces/workspaces-page.tsx
@@ -179,6 +179,7 @@ export default function WorkspacesPage() {
                           size="sm"
                           variant="outline"
                           onClick={() => setWorkspaceToEdit(selectedWorkspace.id)}
+                          aria-label={`Edit ${detail.workspace.name}`}
                         >
                           <Edit2 className="size-4" />
                         </Button>
@@ -187,6 +188,7 @@ export default function WorkspacesPage() {
                           variant="outline"
                           className="text-destructive hover:bg-destructive/10"
                           onClick={() => setWorkspaceToDelete(selectedWorkspace.id)}
+                          aria-label={`Delete ${detail.workspace.name}`}
                         >
                           <Trash2 className="size-4" />
                         </Button>


### PR DESCRIPTION
## Summary

Implements EPIC UX-E7: Dialog and Action Accessibility — ensures key flows are reliable for keyboard and assistive-tech users.

### Changes

**#1558 — Welcome wizard modal safety**
- Set `aria-modal="true"` (was `"false"`)
- Add focus trap (Tab/Shift+Tab wraps within dialog)
- Capture trigger element on open, restore focus on dismiss
- Close on Escape key

**#1566 — Accessible naming for icon-only destructive buttons**
- `chat-panel.tsx`: Added `aria-label` to "Clear session" and "Close chat" buttons
- `workspaces-page.tsx`: Added contextual `aria-label` to Edit and Delete workspace buttons
- `repositories-section.tsx`: Added `aria-label={`Remove ${repo.name}`}` to remove button
- `projects-section.tsx`: Added `aria-label={`Delete ${project.name}`}` to delete button
- `mcp-overrides-page.tsx`: Added `aria-label={`Expire override ${override.toolName}`}` to expire button

**#1567 — Help drawer focus trap and focus-return**
- Add focus trap (Tab/Shift+Tab wraps within drawer)
- Capture trigger element on open, restore focus on close
- `tabIndex={-1}` on dialog root for programmatic focus

### Testing
- New tests: focus-on-mount, Escape key dismiss, Tab wrapping for both wizard and help drawer
- All 505 tests pass (2 pre-existing flaky e2e timeouts excluded)

Closes #1558, #1566, #1567
Closes EPIC #1557